### PR TITLE
docs: update swagger for identity based auth and client endpoints

### DIFF
--- a/services/user-service/docs/docs.go
+++ b/services/user-service/docs/docs.go
@@ -359,6 +359,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
                     }
                 }
             }

--- a/services/user-service/docs/swagger.json
+++ b/services/user-service/docs/swagger.json
@@ -351,6 +351,12 @@
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
                     }
                 }
             }

--- a/services/user-service/docs/swagger.yaml
+++ b/services/user-service/docs/swagger.yaml
@@ -490,6 +490,10 @@ paths:
           description: Conflict
           schema:
             $ref: '#/definitions/errors.AppError'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/errors.AppError'
       summary: Register a new client
       tags:
       - clients

--- a/services/user-service/internal/handler/client_handler.go
+++ b/services/user-service/internal/handler/client_handler.go
@@ -28,6 +28,7 @@ func NewClientHandler(service *service.ClientService) *ClientHandler {
 // @Success 201 {object} map[string]string
 // @Failure 400 {object} errors.AppError
 // @Failure 409 {object} errors.AppError
+// @Failure 503 {object} errors.AppError
 // @Router /api/clients/register [post]
 func (h *ClientHandler) Register(c *gin.Context) {
 	var req dto.CreateClientRequest


### PR DESCRIPTION
# Summary
This PR updates the Swagger documentation to match the new identity auth design, including client endpoints.

## What Changed
The following auth endpoints were moved from employee-scoped routes to shared auth routes:

`POST /api/employees/login` -> `POST /api/auth/login`
`POST /api/employees/activate` -> `POST /api/auth/activate`
`POST /api/employees/forgot-password` -> `POST /api/auth/forgot-password`
`POST /api/employees/reset-password` -> `POST /api/auth/reset-password`
`POST /api/employees/refresh` -> `POST /api/auth/refresh`
`POST /api/employees/change-password` -> `POST /api/auth/change-password`

## Which endpoints were added
`POST /api/clients/register`

## Issue
This PR closes issue #60 