### PR TITLE
refactor: reorganize banking-service routes

### DIFF
--- a/services/banking-service/docs/docs.go
+++ b/services/banking-service/docs/docs.go
@@ -16,53 +16,85 @@ const docTemplate = `{
     "basePath": "{{.BasePath}}",
     "paths": {
         "/api/accounts": {
-        "/api/accounts/{accountId}/cards": {
             "get": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns all active accounts belonging to the authenticated client",
-                "description": "Returns cards for the specified account. Clients can access only their own accounts, while employees can access any account.",
+                "description": "Returns a paginated list of all accounts. Employee access only. Supports filtering by client, account type, kind, status and currency.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "accounts"
                 ],
-                "summary": "List client accounts",
-                    "cards"
-                ],
-                "summary": "List cards for an account",
+                "summary": "List all accounts",
                 "parameters": [
                     {
+                        "type": "integer",
+                        "description": "Filter by client ID",
+                        "name": "client_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
-                        "description": "Account number",
-                        "name": "accountId",
-                        "in": "path",
-                        "required": true
+                        "description": "Filter by account type",
+                        "name": "account_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by account kind",
+                        "name": "account_kind",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filter by currency ID",
+                        "name": "currency_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/banking-service_internal_dto.AccountSummaryResponse"
-                            }
+                            "type": "object"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
-                            "$ref": "#/definitions/dto.AccountCardsResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
@@ -93,7 +125,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.CreateAccountRequest"
+                            "$ref": "#/definitions/dto.CreateAccountRequest"
                         }
                     }
                 ],
@@ -101,14 +133,11 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.AccountResponse"
+                            "$ref": "#/definitions/dto.AccountResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
-                    },
-                    "403": {
-                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
@@ -128,12 +157,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/accounts/{accountNumber}": {
-            "get": {
-                    }
-                }
-            }
-        },
         "/api/cards/request": {
             "post": {
                 "security": [
@@ -141,7 +164,6 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns full details for a specific account owned by the authenticated client",
                 "description": "Client requests a new card for their account. The request is confirmed later using a confirmation code.",
                 "consumes": [
                     "application/json"
@@ -150,16 +172,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "accounts"
-                ],
-                "summary": "Get account details",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Account number",
-                        "name": "accountNumber",
-                        "in": "path",
-                        "required": true
                     "cards"
                 ],
                 "summary": "Request a new card",
@@ -178,7 +190,6 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.AccountResponse"
                             "$ref": "#/definitions/dto.MessageResponse"
                         }
                     },
@@ -205,12 +216,6 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
-                    }
-                }
-            }
-        },
-        "/api/accounts/{accountNumber}/limits": {
-            "put": {
                     },
                     "409": {
                         "description": "Conflict",
@@ -228,7 +233,6 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Confirms a pending limit change request using the verification code from the mobile app",
                 "description": "Confirms a pending card request using the confirmation code and creates the card.",
                 "consumes": [
                     "application/json"
@@ -237,19 +241,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "accounts"
-                ],
-                "summary": "Confirm account limit change",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Account number",
-                        "name": "accountNumber",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Verification code, you can use 1234 for testing but still needs request to be made first",
                     "cards"
                 ],
                 "summary": "Confirm a card request",
@@ -260,14 +251,11 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.ConfirmLimitsChangeRequest"
                             "$ref": "#/definitions/dto.ConfirmCardRequest"
                         }
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK"
                     "201": {
                         "description": "Created",
                         "schema": {
@@ -297,12 +285,6 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
-                    }
-                }
-            }
-        },
-        "/api/accounts/{accountNumber}/limits/request": {
-            "post": {
                     },
                     "409": {
                         "description": "Conflict",
@@ -320,34 +302,11 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Initiates a limit change request for an account. Sends a verification code for confirmation via mobile app, temporarily returned in body as code.",
-                "consumes": [
-                    "application/json"
-                ],
                 "description": "Blocks a card. Clients can block only their own cards, while employees can block any card.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "accounts"
-                ],
-                "summary": "Request account limit change",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Account number",
-                        "name": "accountNumber",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "New daily and monthly limits",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.RequestLimitsChangeRequest"
-                        }
                     "cards"
                 ],
                 "summary": "Block a card",
@@ -364,7 +323,6 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.RequestLimitsChangeResponse"
                             "$ref": "#/definitions/dto.CardResponse"
                         }
                     },
@@ -395,7 +353,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/accounts/{accountNumber}/name": {
         "/api/cards/{cardId}/deactivate": {
             "put": {
                 "security": [
@@ -403,34 +360,11 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates the display name of an account owned by the authenticated client",
-                "consumes": [
-                    "application/json"
-                ],
                 "description": "Deactivates a card permanently. Only employees can perform this action.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "accounts"
-                ],
-                "summary": "Update account name",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Account number",
-                        "name": "accountNumber",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "New account name",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.UpdateAccountNameRequest"
-                        }
                     "cards"
                 ],
                 "summary": "Deactivate a card",
@@ -445,7 +379,6 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.CardResponse"
@@ -478,8 +411,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/accounts/{accountNumber}/payments": {
-            "get": {
         "/api/cards/{cardId}/unblock": {
             "put": {
                 "security": [
@@ -487,8 +418,328 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns a paginated list of payments for an account, filterable by status, date range, and amount. Only the account owner can access this.",
                 "description": "Unblocks a blocked card. Only employees can perform this action.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards"
+                ],
+                "summary": "Unblock a card",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Card ID",
+                        "name": "cardId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.CardResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/cards": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns cards for the specified account. Clients can access only their own accounts, while employees can access any account.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards"
+                ],
+                "summary": "List cards for an account",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account number",
+                        "name": "accountNumber",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.AccountCardsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/limits": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Confirms a pending limit change request using the verification code from the mobile app",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "accounts"
+                ],
+                "summary": "Confirm account limit change",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account number",
+                        "name": "accountNumber",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Verification code generated in mobile app",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ConfirmLimitsChangeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/limits/request": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Initiates a limit change request for an account. Confirmation uses TOTP code generated in the mobile app.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "accounts"
+                ],
+                "summary": "Request account limit change",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account number",
+                        "name": "accountNumber",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New daily and monthly limits",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.RequestLimitsChangeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/name": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Updates the display name of an account owned by the authenticated client",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "accounts"
+                ],
+                "summary": "Update account name",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account number",
+                        "name": "accountNumber",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New account name",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdateAccountNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/payments": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of payments for an account, filterable by status, date range, and amount. Clients can access only their own accounts, employees can access any.",
                 "produces": [
                     "application/json"
                 ],
@@ -497,6 +748,13 @@ const docTemplate = `{
                 ],
                 "summary": "List account payments",
                 "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "Account number",
@@ -548,14 +806,206 @@ const docTemplate = `{
                         "description": "Page size",
                         "name": "page_size",
                         "in": "query"
-                    "cards"
+                    }
                 ],
-                "summary": "Unblock a card",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ListPaymentsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/loans": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a list of loans for a client. Supports sorting by amount.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loans"
+                ],
+                "summary": "List client loans",
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Card ID",
-                        "name": "cardId",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort by amount: 'asc' or 'desc'",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.LoanResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/loans/request": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Client submits a loan request. Validates repayment period and currency, and calculates the monthly installment based on bank margin.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loans"
+                ],
+                "summary": "Submit a loan request",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Loan request data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateLoanRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateLoanResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/loans/{loanId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns detailed loan information including the repayment schedule.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loans"
+                ],
+                "summary": "Get loan details",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Loan ID",
+                        "name": "loanId",
                         "in": "path",
                         "required": true
                     }
@@ -564,8 +1014,237 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.ListPaymentsResponse"
-                            "$ref": "#/definitions/dto.CardResponse"
+                            "$ref": "#/definitions/dto.LoanDetailsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/payments": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of all payments for a client. Supports filtering by status, date range, and amount.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "List all client payments",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status (processing, completed, rejected)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter from date (YYYY-MM-DD)",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to date (YYYY-MM-DD)",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum amount filter",
+                        "name": "min_amount",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Maximum amount filter",
+                        "name": "max_amount",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ListPaymentsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates a new payment from the request body. Only the authenticated client can create payments.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "Create a new payment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Payment data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreatePaymentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreatePaymentResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/payments/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns payment details by ID. Clients can only access their own payments, employees can access any.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "Get payment details",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Payment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.PaymentResponse"
                         }
                     },
                     "400": {
@@ -595,6 +1274,295 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clients/{clientId}/payments/{id}/receipt": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Generates and returns a PDF receipt for a completed payment.",
+                "produces": [
+                    "application/pdf"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "Download payment receipt",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Payment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/payments/{id}/verify": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Confirms a payment using a verification code. Only the client who created the payment can verify it.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "Verify a payment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Payment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Verification code",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.VerifyPaymentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.VerifyPaymentResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/transfers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns transfer history for a client, newest first. Supports pagination.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transfers"
+                ],
+                "summary": "Get client transfer history",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ListTransfersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Executes transfer between two authenticated-client accounts and persists transaction and transfer records atomically.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transfers"
+                ],
+                "summary": "Execute an internal transfer",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Transfer details",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.TransferRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.TransferResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/health": {
             "get": {
                 "description": "Returns service health status",
@@ -617,17 +1585,203 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/loan-requests": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of all loan requests. Employee access only.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loan-requests"
+                ],
+                "summary": "List loan requests",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/loan-requests/{id}/approve": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Approves a pending loan request. Employee access only.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loan-requests"
+                ],
+                "summary": "Approve a loan request",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Loan request ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/loan-requests/{id}/reject": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Rejects a pending loan request. Employee access only.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loan-requests"
+                ],
+                "summary": "Reject a loan request",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Loan request ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
-        "banking-service_internal_dto.AccountResponse": {
-            "type": "object",
-            "properties": {
-                "account_kind": {
         "dto.AccountCardsResponse": {
             "type": "object",
             "properties": {
                 "account_name": {
+                    "type": "string"
+                },
+                "account_number": {
+                    "type": "string"
+                },
+                "cards": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.CardResponse"
+                    }
+                }
+            }
+        },
+        "dto.AccountResponse": {
+            "type": "object",
+            "properties": {
+                "account_kind": {
                     "type": "string"
                 },
                 "account_number": {
@@ -652,7 +1806,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "currency": {
-                    "$ref": "#/definitions/banking-service_internal_model.CurrencyCode"
+                    "$ref": "#/definitions/model.CurrencyCode"
                 },
                 "daily_limit": {
                     "type": "number"
@@ -689,50 +1843,6 @@ const docTemplate = `{
                 }
             }
         },
-        "banking-service_internal_dto.AccountSummaryResponse": {
-            "type": "object",
-            "properties": {
-                "account_kind": {
-                    "type": "string"
-                },
-                "account_number": {
-                    "type": "string"
-                },
-                "account_type": {
-                    "type": "string"
-                },
-                "available_balance": {
-                    "type": "number"
-                },
-                "balance": {
-                    "type": "number"
-                },
-                "currency": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "reserved_funds": {
-                    "type": "number"
-                }
-            }
-        },
-        "banking-service_internal_dto.ConfirmLimitsChangeRequest": {
-            "type": "object",
-            "required": [
-                "code"
-            ],
-            "properties": {
-                "code": {
-                "cards": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/dto.CardResponse"
-                    }
-                }
-            }
-        },
         "dto.AuthorizedPersonRequest": {
             "type": "object",
             "required": [
@@ -766,114 +1876,6 @@ const docTemplate = `{
                 }
             }
         },
-        "banking-service_internal_dto.CreateAccountRequest": {
-            "type": "object",
-            "required": [
-                "account_kind",
-                "account_type",
-                "client_id",
-                "employee_id",
-                "expires_at",
-                "name"
-            ],
-            "properties": {
-                "account_kind": {
-                    "$ref": "#/definitions/banking-service_internal_model.AccountKind"
-                },
-                "account_type": {
-                    "$ref": "#/definitions/banking-service_internal_model.AccountType"
-                },
-                "client_id": {
-                    "type": "integer"
-                },
-                "company_id": {
-                    "type": "integer"
-                },
-                "create_card": {
-                    "type": "boolean"
-                },
-                "currency_code": {
-                    "description": "required if AccountKind=Foreign",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/banking-service_internal_model.CurrencyCode"
-                        }
-                    ]
-                },
-                "employee_id": {
-                    "type": "integer"
-                },
-                "expires_at": {
-                    "type": "string"
-                },
-                "initial_balance": {
-                    "type": "number",
-                    "minimum": 0
-                },
-                "name": {
-                    "type": "string"
-                },
-                "subtype": {
-                    "description": "required if AccountKind=Current",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/banking-service_internal_model.Subtype"
-                        }
-                    ]
-                }
-            }
-        },
-        "banking-service_internal_dto.ListPaymentsResponse": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/banking-service_internal_dto.PaymentSummaryResponse"
-                    }
-                },
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "total": {
-                    "type": "integer"
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "banking-service_internal_dto.PaymentSummaryResponse": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "type": "number"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "currency": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "payer_account": {
-                    "type": "string"
-                },
-                "payment_code": {
-                    "type": "string"
-                },
-                "purpose": {
-                    "type": "string"
-                },
-                "recipient_account": {
-                    "type": "string"
-                },
-                "recipient_name": {
         "dto.CardResponse": {
             "type": "object",
             "properties": {
@@ -912,25 +1914,6 @@ const docTemplate = `{
                 }
             }
         },
-        "banking-service_internal_dto.RequestLimitsChangeRequest": {
-            "type": "object",
-            "required": [
-                "daily_limit",
-                "monthly_limit"
-            ],
-            "properties": {
-                "daily_limit": {
-                    "type": "number"
-                },
-                "monthly_limit": {
-                    "type": "number"
-                }
-            }
-        },
-        "banking-service_internal_dto.RequestLimitsChangeResponse": {
-            "type": "object",
-            "properties": {
-                "code": {
         "dto.ConfirmCardRequest": {
             "type": "object",
             "required": [
@@ -946,6 +1929,274 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.ConfirmLimitsChangeRequest": {
+            "type": "object",
+            "required": [
+                "code"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CreateAccountRequest": {
+            "type": "object",
+            "required": [
+                "account_kind",
+                "account_type",
+                "client_id",
+                "employee_id",
+                "expires_at",
+                "name"
+            ],
+            "properties": {
+                "account_kind": {
+                    "$ref": "#/definitions/model.AccountKind"
+                },
+                "account_type": {
+                    "$ref": "#/definitions/model.AccountType"
+                },
+                "client_id": {
+                    "type": "integer"
+                },
+                "company_id": {
+                    "type": "integer"
+                },
+                "create_card": {
+                    "type": "boolean"
+                },
+                "currency_code": {
+                    "description": "required if AccountKind=Foreign",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.CurrencyCode"
+                        }
+                    ]
+                },
+                "employee_id": {
+                    "type": "integer"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "generate_card": {
+                    "type": "boolean"
+                },
+                "initial_balance": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "name": {
+                    "type": "string"
+                },
+                "subtype": {
+                    "description": "required if AccountKind=Current",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.Subtype"
+                        }
+                    ]
+                }
+            }
+        },
+        "dto.CreateLoanRequest": {
+            "type": "object",
+            "required": [
+                "account_number",
+                "amount",
+                "loan_type_id",
+                "repayment_period"
+            ],
+            "properties": {
+                "account_number": {
+                    "type": "string"
+                },
+                "amount": {
+                    "type": "number"
+                },
+                "loan_type_id": {
+                    "type": "integer"
+                },
+                "repayment_period": {
+                    "description": "Broj meseci",
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.CreateLoanResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "monthly_installment": {
+                    "type": "number"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.LoanRequestStatus"
+                }
+            }
+        },
+        "dto.CreatePaymentRequest": {
+            "type": "object",
+            "required": [
+                "amount",
+                "payer_account_number",
+                "recipient_account_number",
+                "recipient_name"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "payer_account_number": {
+                    "type": "string"
+                },
+                "payment_code": {
+                    "type": "string"
+                },
+                "purpose": {
+                    "type": "string"
+                },
+                "recipient_account_number": {
+                    "type": "string"
+                },
+                "recipient_name": {
+                    "type": "string"
+                },
+                "reference_number": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CreatePaymentResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.Installment": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "number": {
+                    "type": "integer"
+                },
+                "status": {
+                    "description": "npr. \"PAID\", \"UPCOMING\"",
+                    "type": "string"
+                }
+            }
+        },
+        "dto.ListPaymentsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.PaymentSummaryResponse"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.ListTransfersResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.TransferResponse"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.LoanDetailsResponse": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "currency": {
+                    "$ref": "#/definitions/model.CurrencyCode"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "installments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.Installment"
+                    }
+                },
+                "interest_rate": {
+                    "type": "number"
+                },
+                "loan_type": {
+                    "type": "string"
+                },
+                "monthly_installment": {
+                    "type": "number"
+                },
+                "repayment_period": {
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.LoanRequestStatus"
+                }
+            }
+        },
+        "dto.LoanResponse": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "currency": {
+                    "$ref": "#/definitions/model.CurrencyCode"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "loan_type": {
+                    "type": "string"
+                },
+                "monthly_installment": {
+                    "type": "number"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.LoanRequestStatus"
+                }
+            }
+        },
         "dto.MessageResponse": {
             "type": "object",
             "properties": {
@@ -954,7 +2205,160 @@ const docTemplate = `{
                 }
             }
         },
-        "banking-service_internal_dto.UpdateAccountNameRequest": {
+        "dto.PaymentResponse": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "currency_code": {
+                    "type": "string"
+                },
+                "payer_account_number": {
+                    "type": "string"
+                },
+                "payment_code": {
+                    "type": "string"
+                },
+                "payment_id": {
+                    "type": "integer"
+                },
+                "purpose": {
+                    "type": "string"
+                },
+                "recipient_account_number": {
+                    "type": "string"
+                },
+                "recipient_name": {
+                    "type": "string"
+                },
+                "reference_number": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.PaymentSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "payer_account": {
+                    "type": "string"
+                },
+                "payment_code": {
+                    "type": "string"
+                },
+                "purpose": {
+                    "type": "string"
+                },
+                "recipient_account": {
+                    "type": "string"
+                },
+                "recipient_name": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.RequestCardRequest": {
+            "type": "object",
+            "required": [
+                "account_number"
+            ],
+            "properties": {
+                "account_number": {
+                    "type": "string"
+                },
+                "authorized_person": {
+                    "$ref": "#/definitions/dto.AuthorizedPersonRequest"
+                }
+            }
+        },
+        "dto.RequestLimitsChangeRequest": {
+            "type": "object",
+            "required": [
+                "daily_limit",
+                "monthly_limit"
+            ],
+            "properties": {
+                "daily_limit": {
+                    "type": "number"
+                },
+                "monthly_limit": {
+                    "type": "number"
+                }
+            }
+        },
+        "dto.TransferRequest": {
+            "type": "object",
+            "required": [
+                "amount",
+                "from_account",
+                "to_account"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "from_account": {
+                    "type": "string"
+                },
+                "to_account": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.TransferResponse": {
+            "type": "object",
+            "properties": {
+                "commission": {
+                    "type": "number"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "exchange_rate": {
+                    "type": "number"
+                },
+                "final_amount": {
+                    "type": "number"
+                },
+                "from_account_number": {
+                    "type": "string"
+                },
+                "initial_amount": {
+                    "type": "number"
+                },
+                "to_account_number": {
+                    "type": "string"
+                },
+                "transaction_id": {
+                    "type": "integer"
+                },
+                "transfer_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.UpdateAccountNameRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -965,29 +2369,66 @@ const docTemplate = `{
                 }
             }
         },
-        "banking-service_internal_model.AccountKind": {
+        "dto.VerifyPaymentRequest": {
+            "type": "object",
+            "required": [
+                "code"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.VerifyPaymentResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "errors.AppError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.AccountKind": {
             "type": "string",
             "enum": [
                 "Current",
-                "Foreign"
+                "Foreign",
+                "Internal"
             ],
             "x-enum-varnames": [
                 "AccountKindCurrent",
-                "AccountKindForeign"
+                "AccountKindForeign",
+                "AccountKindInternal"
             ]
         },
-        "banking-service_internal_model.AccountType": {
+        "model.AccountType": {
             "type": "string",
             "enum": [
                 "Personal",
-                "Business"
+                "Business",
+                "Bank"
             ],
             "x-enum-varnames": [
                 "AccountTypePersonal",
-                "AccountTypeBusiness"
+                "AccountTypeBusiness",
+                "AccountTypeBank"
             ]
         },
-        "banking-service_internal_model.CurrencyCode": {
+        "model.CurrencyCode": {
             "type": "string",
             "enum": [
                 "EUR",
@@ -1010,7 +2451,20 @@ const docTemplate = `{
                 "RSD"
             ]
         },
-        "banking-service_internal_model.Subtype": {
+        "model.LoanRequestStatus": {
+            "type": "string",
+            "enum": [
+                "PENDING",
+                "APPROVED",
+                "REJECTED"
+            ],
+            "x-enum-varnames": [
+                "LoanRequestPending",
+                "LoanRequestApproved",
+                "LoanRequestRejected"
+            ]
+        },
+        "model.Subtype": {
             "type": "string",
             "enum": [
                 "Standard",
@@ -1034,34 +2488,6 @@ const docTemplate = `{
                 "SubtypeJointStock",
                 "SubtypeFoundation"
             ]
-        },
-        "dto.RequestCardRequest": {
-            "type": "object",
-            "required": [
-                "account_number"
-            ],
-            "properties": {
-                "account_number": {
-                    "type": "string"
-                },
-                "authorized_person": {
-                    "$ref": "#/definitions/dto.AuthorizedPersonRequest"
-                }
-            }
-        },
-        "errors.AppError": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "string"
-                }
-            }
         }
     },
     "securityDefinitions": {

--- a/services/banking-service/docs/swagger.json
+++ b/services/banking-service/docs/swagger.json
@@ -8,53 +8,85 @@
     },
     "paths": {
         "/api/accounts": {
-        "/api/accounts/{accountId}/cards": {
             "get": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns all active accounts belonging to the authenticated client",
-                "description": "Returns cards for the specified account. Clients can access only their own accounts, while employees can access any account.",
+                "description": "Returns a paginated list of all accounts. Employee access only. Supports filtering by client, account type, kind, status and currency.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "accounts"
                 ],
-                "summary": "List client accounts",
-                    "cards"
-                ],
-                "summary": "List cards for an account",
+                "summary": "List all accounts",
                 "parameters": [
                     {
+                        "type": "integer",
+                        "description": "Filter by client ID",
+                        "name": "client_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
-                        "description": "Account number",
-                        "name": "accountId",
-                        "in": "path",
-                        "required": true
+                        "description": "Filter by account type",
+                        "name": "account_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by account kind",
+                        "name": "account_kind",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filter by currency ID",
+                        "name": "currency_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/banking-service_internal_dto.AccountSummaryResponse"
-                            }
+                            "type": "object"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
-                            "$ref": "#/definitions/dto.AccountCardsResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
@@ -85,7 +117,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.CreateAccountRequest"
+                            "$ref": "#/definitions/dto.CreateAccountRequest"
                         }
                     }
                 ],
@@ -93,14 +125,11 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.AccountResponse"
+                            "$ref": "#/definitions/dto.AccountResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
-                    },
-                    "403": {
-                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
@@ -120,12 +149,6 @@
                 }
             }
         },
-        "/api/accounts/{accountNumber}": {
-            "get": {
-                    }
-                }
-            }
-        },
         "/api/cards/request": {
             "post": {
                 "security": [
@@ -133,7 +156,6 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns full details for a specific account owned by the authenticated client",
                 "description": "Client requests a new card for their account. The request is confirmed later using a confirmation code.",
                 "consumes": [
                     "application/json"
@@ -142,16 +164,6 @@
                     "application/json"
                 ],
                 "tags": [
-                    "accounts"
-                ],
-                "summary": "Get account details",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Account number",
-                        "name": "accountNumber",
-                        "in": "path",
-                        "required": true
                     "cards"
                 ],
                 "summary": "Request a new card",
@@ -170,7 +182,6 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.AccountResponse"
                             "$ref": "#/definitions/dto.MessageResponse"
                         }
                     },
@@ -197,12 +208,6 @@
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
-                    }
-                }
-            }
-        },
-        "/api/accounts/{accountNumber}/limits": {
-            "put": {
                     },
                     "409": {
                         "description": "Conflict",
@@ -220,7 +225,6 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Confirms a pending limit change request using the verification code from the mobile app",
                 "description": "Confirms a pending card request using the confirmation code and creates the card.",
                 "consumes": [
                     "application/json"
@@ -229,19 +233,6 @@
                     "application/json"
                 ],
                 "tags": [
-                    "accounts"
-                ],
-                "summary": "Confirm account limit change",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Account number",
-                        "name": "accountNumber",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Verification code, you can use 1234 for testing but still needs request to be made first",
                     "cards"
                 ],
                 "summary": "Confirm a card request",
@@ -252,14 +243,11 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.ConfirmLimitsChangeRequest"
                             "$ref": "#/definitions/dto.ConfirmCardRequest"
                         }
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK"
                     "201": {
                         "description": "Created",
                         "schema": {
@@ -289,12 +277,6 @@
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
-                    }
-                }
-            }
-        },
-        "/api/accounts/{accountNumber}/limits/request": {
-            "post": {
                     },
                     "409": {
                         "description": "Conflict",
@@ -312,34 +294,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Initiates a limit change request for an account. Sends a verification code for confirmation via mobile app, temporarily returned in body as code.",
-                "consumes": [
-                    "application/json"
-                ],
                 "description": "Blocks a card. Clients can block only their own cards, while employees can block any card.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "accounts"
-                ],
-                "summary": "Request account limit change",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Account number",
-                        "name": "accountNumber",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "New daily and monthly limits",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.RequestLimitsChangeRequest"
-                        }
                     "cards"
                 ],
                 "summary": "Block a card",
@@ -356,7 +315,6 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.RequestLimitsChangeResponse"
                             "$ref": "#/definitions/dto.CardResponse"
                         }
                     },
@@ -387,7 +345,6 @@
                 }
             }
         },
-        "/api/accounts/{accountNumber}/name": {
         "/api/cards/{cardId}/deactivate": {
             "put": {
                 "security": [
@@ -395,34 +352,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates the display name of an account owned by the authenticated client",
-                "consumes": [
-                    "application/json"
-                ],
                 "description": "Deactivates a card permanently. Only employees can perform this action.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "accounts"
-                ],
-                "summary": "Update account name",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Account number",
-                        "name": "accountNumber",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "New account name",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.UpdateAccountNameRequest"
-                        }
                     "cards"
                 ],
                 "summary": "Deactivate a card",
@@ -437,7 +371,6 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.CardResponse"
@@ -470,8 +403,6 @@
                 }
             }
         },
-        "/api/accounts/{accountNumber}/payments": {
-            "get": {
         "/api/cards/{cardId}/unblock": {
             "put": {
                 "security": [
@@ -479,8 +410,328 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns a paginated list of payments for an account, filterable by status, date range, and amount. Only the account owner can access this.",
                 "description": "Unblocks a blocked card. Only employees can perform this action.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards"
+                ],
+                "summary": "Unblock a card",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Card ID",
+                        "name": "cardId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.CardResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/cards": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns cards for the specified account. Clients can access only their own accounts, while employees can access any account.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards"
+                ],
+                "summary": "List cards for an account",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account number",
+                        "name": "accountNumber",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.AccountCardsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/limits": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Confirms a pending limit change request using the verification code from the mobile app",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "accounts"
+                ],
+                "summary": "Confirm account limit change",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account number",
+                        "name": "accountNumber",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Verification code generated in mobile app",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ConfirmLimitsChangeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/limits/request": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Initiates a limit change request for an account. Confirmation uses TOTP code generated in the mobile app.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "accounts"
+                ],
+                "summary": "Request account limit change",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account number",
+                        "name": "accountNumber",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New daily and monthly limits",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.RequestLimitsChangeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/name": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Updates the display name of an account owned by the authenticated client",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "accounts"
+                ],
+                "summary": "Update account name",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account number",
+                        "name": "accountNumber",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New account name",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdateAccountNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/accounts/{accountNumber}/payments": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of payments for an account, filterable by status, date range, and amount. Clients can access only their own accounts, employees can access any.",
                 "produces": [
                     "application/json"
                 ],
@@ -489,6 +740,13 @@
                 ],
                 "summary": "List account payments",
                 "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "Account number",
@@ -540,14 +798,206 @@
                         "description": "Page size",
                         "name": "page_size",
                         "in": "query"
-                    "cards"
+                    }
                 ],
-                "summary": "Unblock a card",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ListPaymentsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/loans": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a list of loans for a client. Supports sorting by amount.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loans"
+                ],
+                "summary": "List client loans",
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Card ID",
-                        "name": "cardId",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort by amount: 'asc' or 'desc'",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.LoanResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/loans/request": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Client submits a loan request. Validates repayment period and currency, and calculates the monthly installment based on bank margin.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loans"
+                ],
+                "summary": "Submit a loan request",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Loan request data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateLoanRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateLoanResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/loans/{loanId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns detailed loan information including the repayment schedule.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loans"
+                ],
+                "summary": "Get loan details",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Loan ID",
+                        "name": "loanId",
                         "in": "path",
                         "required": true
                     }
@@ -556,8 +1006,237 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/banking-service_internal_dto.ListPaymentsResponse"
-                            "$ref": "#/definitions/dto.CardResponse"
+                            "$ref": "#/definitions/dto.LoanDetailsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/payments": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of all payments for a client. Supports filtering by status, date range, and amount.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "List all client payments",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status (processing, completed, rejected)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter from date (YYYY-MM-DD)",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to date (YYYY-MM-DD)",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Minimum amount filter",
+                        "name": "min_amount",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "Maximum amount filter",
+                        "name": "max_amount",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ListPaymentsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates a new payment from the request body. Only the authenticated client can create payments.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "Create a new payment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Payment data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreatePaymentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreatePaymentResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/payments/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns payment details by ID. Clients can only access their own payments, employees can access any.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "Get payment details",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Payment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.PaymentResponse"
                         }
                     },
                     "400": {
@@ -587,6 +1266,295 @@
                 }
             }
         },
+        "/api/clients/{clientId}/payments/{id}/receipt": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Generates and returns a PDF receipt for a completed payment.",
+                "produces": [
+                    "application/pdf"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "Download payment receipt",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Payment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/payments/{id}/verify": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Confirms a payment using a verification code. Only the client who created the payment can verify it.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "payments"
+                ],
+                "summary": "Verify a payment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Payment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Verification code",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.VerifyPaymentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.VerifyPaymentResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{clientId}/transfers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns transfer history for a client, newest first. Supports pagination.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transfers"
+                ],
+                "summary": "Get client transfer history",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ListTransfersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Executes transfer between two authenticated-client accounts and persists transaction and transfer records atomically.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transfers"
+                ],
+                "summary": "Execute an internal transfer",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "clientId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Transfer details",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.TransferRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.TransferResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/health": {
             "get": {
                 "description": "Returns service health status",
@@ -609,17 +1577,203 @@
                     }
                 }
             }
+        },
+        "/api/loan-requests": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of all loan requests. Employee access only.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loan-requests"
+                ],
+                "summary": "List loan requests",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/loan-requests/{id}/approve": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Approves a pending loan request. Employee access only.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loan-requests"
+                ],
+                "summary": "Approve a loan request",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Loan request ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/loan-requests/{id}/reject": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Rejects a pending loan request. Employee access only.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "loan-requests"
+                ],
+                "summary": "Reject a loan request",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Loan request ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
-        "banking-service_internal_dto.AccountResponse": {
-            "type": "object",
-            "properties": {
-                "account_kind": {
         "dto.AccountCardsResponse": {
             "type": "object",
             "properties": {
                 "account_name": {
+                    "type": "string"
+                },
+                "account_number": {
+                    "type": "string"
+                },
+                "cards": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.CardResponse"
+                    }
+                }
+            }
+        },
+        "dto.AccountResponse": {
+            "type": "object",
+            "properties": {
+                "account_kind": {
                     "type": "string"
                 },
                 "account_number": {
@@ -644,7 +1798,7 @@
                     "type": "string"
                 },
                 "currency": {
-                    "$ref": "#/definitions/banking-service_internal_model.CurrencyCode"
+                    "$ref": "#/definitions/model.CurrencyCode"
                 },
                 "daily_limit": {
                     "type": "number"
@@ -681,50 +1835,6 @@
                 }
             }
         },
-        "banking-service_internal_dto.AccountSummaryResponse": {
-            "type": "object",
-            "properties": {
-                "account_kind": {
-                    "type": "string"
-                },
-                "account_number": {
-                    "type": "string"
-                },
-                "account_type": {
-                    "type": "string"
-                },
-                "available_balance": {
-                    "type": "number"
-                },
-                "balance": {
-                    "type": "number"
-                },
-                "currency": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "reserved_funds": {
-                    "type": "number"
-                }
-            }
-        },
-        "banking-service_internal_dto.ConfirmLimitsChangeRequest": {
-            "type": "object",
-            "required": [
-                "code"
-            ],
-            "properties": {
-                "code": {
-                "cards": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/dto.CardResponse"
-                    }
-                }
-            }
-        },
         "dto.AuthorizedPersonRequest": {
             "type": "object",
             "required": [
@@ -758,114 +1868,6 @@
                 }
             }
         },
-        "banking-service_internal_dto.CreateAccountRequest": {
-            "type": "object",
-            "required": [
-                "account_kind",
-                "account_type",
-                "client_id",
-                "employee_id",
-                "expires_at",
-                "name"
-            ],
-            "properties": {
-                "account_kind": {
-                    "$ref": "#/definitions/banking-service_internal_model.AccountKind"
-                },
-                "account_type": {
-                    "$ref": "#/definitions/banking-service_internal_model.AccountType"
-                },
-                "client_id": {
-                    "type": "integer"
-                },
-                "company_id": {
-                    "type": "integer"
-                },
-                "create_card": {
-                    "type": "boolean"
-                },
-                "currency_code": {
-                    "description": "required if AccountKind=Foreign",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/banking-service_internal_model.CurrencyCode"
-                        }
-                    ]
-                },
-                "employee_id": {
-                    "type": "integer"
-                },
-                "expires_at": {
-                    "type": "string"
-                },
-                "initial_balance": {
-                    "type": "number",
-                    "minimum": 0
-                },
-                "name": {
-                    "type": "string"
-                },
-                "subtype": {
-                    "description": "required if AccountKind=Current",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/banking-service_internal_model.Subtype"
-                        }
-                    ]
-                }
-            }
-        },
-        "banking-service_internal_dto.ListPaymentsResponse": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/banking-service_internal_dto.PaymentSummaryResponse"
-                    }
-                },
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "total": {
-                    "type": "integer"
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "banking-service_internal_dto.PaymentSummaryResponse": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "type": "number"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "currency": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "payer_account": {
-                    "type": "string"
-                },
-                "payment_code": {
-                    "type": "string"
-                },
-                "purpose": {
-                    "type": "string"
-                },
-                "recipient_account": {
-                    "type": "string"
-                },
-                "recipient_name": {
         "dto.CardResponse": {
             "type": "object",
             "properties": {
@@ -904,25 +1906,6 @@
                 }
             }
         },
-        "banking-service_internal_dto.RequestLimitsChangeRequest": {
-            "type": "object",
-            "required": [
-                "daily_limit",
-                "monthly_limit"
-            ],
-            "properties": {
-                "daily_limit": {
-                    "type": "number"
-                },
-                "monthly_limit": {
-                    "type": "number"
-                }
-            }
-        },
-        "banking-service_internal_dto.RequestLimitsChangeResponse": {
-            "type": "object",
-            "properties": {
-                "code": {
         "dto.ConfirmCardRequest": {
             "type": "object",
             "required": [
@@ -938,6 +1921,274 @@
                 }
             }
         },
+        "dto.ConfirmLimitsChangeRequest": {
+            "type": "object",
+            "required": [
+                "code"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CreateAccountRequest": {
+            "type": "object",
+            "required": [
+                "account_kind",
+                "account_type",
+                "client_id",
+                "employee_id",
+                "expires_at",
+                "name"
+            ],
+            "properties": {
+                "account_kind": {
+                    "$ref": "#/definitions/model.AccountKind"
+                },
+                "account_type": {
+                    "$ref": "#/definitions/model.AccountType"
+                },
+                "client_id": {
+                    "type": "integer"
+                },
+                "company_id": {
+                    "type": "integer"
+                },
+                "create_card": {
+                    "type": "boolean"
+                },
+                "currency_code": {
+                    "description": "required if AccountKind=Foreign",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.CurrencyCode"
+                        }
+                    ]
+                },
+                "employee_id": {
+                    "type": "integer"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "generate_card": {
+                    "type": "boolean"
+                },
+                "initial_balance": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "name": {
+                    "type": "string"
+                },
+                "subtype": {
+                    "description": "required if AccountKind=Current",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.Subtype"
+                        }
+                    ]
+                }
+            }
+        },
+        "dto.CreateLoanRequest": {
+            "type": "object",
+            "required": [
+                "account_number",
+                "amount",
+                "loan_type_id",
+                "repayment_period"
+            ],
+            "properties": {
+                "account_number": {
+                    "type": "string"
+                },
+                "amount": {
+                    "type": "number"
+                },
+                "loan_type_id": {
+                    "type": "integer"
+                },
+                "repayment_period": {
+                    "description": "Broj meseci",
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.CreateLoanResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "monthly_installment": {
+                    "type": "number"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.LoanRequestStatus"
+                }
+            }
+        },
+        "dto.CreatePaymentRequest": {
+            "type": "object",
+            "required": [
+                "amount",
+                "payer_account_number",
+                "recipient_account_number",
+                "recipient_name"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "payer_account_number": {
+                    "type": "string"
+                },
+                "payment_code": {
+                    "type": "string"
+                },
+                "purpose": {
+                    "type": "string"
+                },
+                "recipient_account_number": {
+                    "type": "string"
+                },
+                "recipient_name": {
+                    "type": "string"
+                },
+                "reference_number": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CreatePaymentResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.Installment": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "number": {
+                    "type": "integer"
+                },
+                "status": {
+                    "description": "npr. \"PAID\", \"UPCOMING\"",
+                    "type": "string"
+                }
+            }
+        },
+        "dto.ListPaymentsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.PaymentSummaryResponse"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.ListTransfersResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.TransferResponse"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.LoanDetailsResponse": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "currency": {
+                    "$ref": "#/definitions/model.CurrencyCode"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "installments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.Installment"
+                    }
+                },
+                "interest_rate": {
+                    "type": "number"
+                },
+                "loan_type": {
+                    "type": "string"
+                },
+                "monthly_installment": {
+                    "type": "number"
+                },
+                "repayment_period": {
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.LoanRequestStatus"
+                }
+            }
+        },
+        "dto.LoanResponse": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "currency": {
+                    "$ref": "#/definitions/model.CurrencyCode"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "loan_type": {
+                    "type": "string"
+                },
+                "monthly_installment": {
+                    "type": "number"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.LoanRequestStatus"
+                }
+            }
+        },
         "dto.MessageResponse": {
             "type": "object",
             "properties": {
@@ -946,7 +2197,160 @@
                 }
             }
         },
-        "banking-service_internal_dto.UpdateAccountNameRequest": {
+        "dto.PaymentResponse": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "currency_code": {
+                    "type": "string"
+                },
+                "payer_account_number": {
+                    "type": "string"
+                },
+                "payment_code": {
+                    "type": "string"
+                },
+                "payment_id": {
+                    "type": "integer"
+                },
+                "purpose": {
+                    "type": "string"
+                },
+                "recipient_account_number": {
+                    "type": "string"
+                },
+                "recipient_name": {
+                    "type": "string"
+                },
+                "reference_number": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.PaymentSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "payer_account": {
+                    "type": "string"
+                },
+                "payment_code": {
+                    "type": "string"
+                },
+                "purpose": {
+                    "type": "string"
+                },
+                "recipient_account": {
+                    "type": "string"
+                },
+                "recipient_name": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.RequestCardRequest": {
+            "type": "object",
+            "required": [
+                "account_number"
+            ],
+            "properties": {
+                "account_number": {
+                    "type": "string"
+                },
+                "authorized_person": {
+                    "$ref": "#/definitions/dto.AuthorizedPersonRequest"
+                }
+            }
+        },
+        "dto.RequestLimitsChangeRequest": {
+            "type": "object",
+            "required": [
+                "daily_limit",
+                "monthly_limit"
+            ],
+            "properties": {
+                "daily_limit": {
+                    "type": "number"
+                },
+                "monthly_limit": {
+                    "type": "number"
+                }
+            }
+        },
+        "dto.TransferRequest": {
+            "type": "object",
+            "required": [
+                "amount",
+                "from_account",
+                "to_account"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "from_account": {
+                    "type": "string"
+                },
+                "to_account": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.TransferResponse": {
+            "type": "object",
+            "properties": {
+                "commission": {
+                    "type": "number"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "exchange_rate": {
+                    "type": "number"
+                },
+                "final_amount": {
+                    "type": "number"
+                },
+                "from_account_number": {
+                    "type": "string"
+                },
+                "initial_amount": {
+                    "type": "number"
+                },
+                "to_account_number": {
+                    "type": "string"
+                },
+                "transaction_id": {
+                    "type": "integer"
+                },
+                "transfer_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.UpdateAccountNameRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -957,29 +2361,66 @@
                 }
             }
         },
-        "banking-service_internal_model.AccountKind": {
+        "dto.VerifyPaymentRequest": {
+            "type": "object",
+            "required": [
+                "code"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.VerifyPaymentResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "errors.AppError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.AccountKind": {
             "type": "string",
             "enum": [
                 "Current",
-                "Foreign"
+                "Foreign",
+                "Internal"
             ],
             "x-enum-varnames": [
                 "AccountKindCurrent",
-                "AccountKindForeign"
+                "AccountKindForeign",
+                "AccountKindInternal"
             ]
         },
-        "banking-service_internal_model.AccountType": {
+        "model.AccountType": {
             "type": "string",
             "enum": [
                 "Personal",
-                "Business"
+                "Business",
+                "Bank"
             ],
             "x-enum-varnames": [
                 "AccountTypePersonal",
-                "AccountTypeBusiness"
+                "AccountTypeBusiness",
+                "AccountTypeBank"
             ]
         },
-        "banking-service_internal_model.CurrencyCode": {
+        "model.CurrencyCode": {
             "type": "string",
             "enum": [
                 "EUR",
@@ -1002,7 +2443,20 @@
                 "RSD"
             ]
         },
-        "banking-service_internal_model.Subtype": {
+        "model.LoanRequestStatus": {
+            "type": "string",
+            "enum": [
+                "PENDING",
+                "APPROVED",
+                "REJECTED"
+            ],
+            "x-enum-varnames": [
+                "LoanRequestPending",
+                "LoanRequestApproved",
+                "LoanRequestRejected"
+            ]
+        },
+        "model.Subtype": {
             "type": "string",
             "enum": [
                 "Standard",
@@ -1026,34 +2480,6 @@
                 "SubtypeJointStock",
                 "SubtypeFoundation"
             ]
-        },
-        "dto.RequestCardRequest": {
-            "type": "object",
-            "required": [
-                "account_number"
-            ],
-            "properties": {
-                "account_number": {
-                    "type": "string"
-                },
-                "authorized_person": {
-                    "$ref": "#/definitions/dto.AuthorizedPersonRequest"
-                }
-            }
-        },
-        "errors.AppError": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "string"
-                }
-            }
         }
     },
     "securityDefinitions": {

--- a/services/banking-service/docs/swagger.yaml
+++ b/services/banking-service/docs/swagger.yaml
@@ -1,5 +1,16 @@
 definitions:
-  banking-service_internal_dto.AccountResponse:
+  dto.AccountCardsResponse:
+    properties:
+      account_name:
+        type: string
+      account_number:
+        type: string
+      cards:
+        items:
+          $ref: '#/definitions/dto.CardResponse'
+        type: array
+    type: object
+  dto.AccountResponse:
     properties:
       account_kind:
         type: string
@@ -18,7 +29,7 @@ definitions:
       created_at:
         type: string
       currency:
-        $ref: '#/definitions/banking-service_internal_model.CurrencyCode'
+        $ref: '#/definitions/model.CurrencyCode'
       daily_limit:
         type: number
       daily_spending:
@@ -41,114 +52,6 @@ definitions:
         type: string
       subtype:
         type: string
-    type: object
-  banking-service_internal_dto.AccountSummaryResponse:
-    properties:
-      account_kind:
-        type: string
-      account_number:
-        type: string
-      account_type:
-        type: string
-      available_balance:
-        type: number
-      balance:
-        type: number
-      currency:
-        type: string
-      name:
-        type: string
-      reserved_funds:
-        type: number
-    type: object
-  banking-service_internal_dto.ConfirmLimitsChangeRequest:
-    properties:
-      code:
-        type: string
-    required:
-    - code
-    type: object
-  banking-service_internal_dto.CreateAccountRequest:
-    properties:
-      account_kind:
-        $ref: '#/definitions/banking-service_internal_model.AccountKind'
-      account_type:
-        $ref: '#/definitions/banking-service_internal_model.AccountType'
-      client_id:
-        type: integer
-      company_id:
-        type: integer
-      create_card:
-        type: boolean
-      currency_code:
-        allOf:
-        - $ref: '#/definitions/banking-service_internal_model.CurrencyCode'
-        description: required if AccountKind=Foreign
-      employee_id:
-        type: integer
-      expires_at:
-        type: string
-      initial_balance:
-        minimum: 0
-        type: number
-      name:
-        type: string
-      subtype:
-        allOf:
-        - $ref: '#/definitions/banking-service_internal_model.Subtype'
-        description: required if AccountKind=Current
-    required:
-    - account_kind
-    - account_type
-    - client_id
-    - employee_id
-    - expires_at
-    - name
-    type: object
-  banking-service_internal_dto.ListPaymentsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/banking-service_internal_dto.PaymentSummaryResponse'
-        type: array
-      page:
-        type: integer
-      page_size:
-        type: integer
-      total:
-        type: integer
-      total_pages:
-        type: integer
-    type: object
-  banking-service_internal_dto.PaymentSummaryResponse:
-    properties:
-      amount:
-        type: number
-      created_at:
-        type: string
-      currency:
-        type: string
-      id:
-        type: integer
-      payer_account:
-        type: string
-      payment_code:
-        type: string
-      purpose:
-        type: string
-      recipient_account:
-        type: string
-      recipient_name:
-  dto.AccountCardsResponse:
-    properties:
-      account_name:
-        type: string
-      account_number:
-        type: string
-      cards:
-        items:
-          $ref: '#/definitions/dto.CardResponse'
-        type: array
     type: object
   dto.AuthorizedPersonRequest:
     properties:
@@ -198,7 +101,256 @@ definitions:
       status:
         type: string
     type: object
-  banking-service_internal_dto.RequestLimitsChangeRequest:
+  dto.ConfirmCardRequest:
+    properties:
+      account_number:
+        type: string
+      confirmation_code:
+        type: string
+    required:
+    - account_number
+    - confirmation_code
+    type: object
+  dto.ConfirmLimitsChangeRequest:
+    properties:
+      code:
+        type: string
+    required:
+    - code
+    type: object
+  dto.CreateAccountRequest:
+    properties:
+      account_kind:
+        $ref: '#/definitions/model.AccountKind'
+      account_type:
+        $ref: '#/definitions/model.AccountType'
+      client_id:
+        type: integer
+      company_id:
+        type: integer
+      create_card:
+        type: boolean
+      currency_code:
+        allOf:
+        - $ref: '#/definitions/model.CurrencyCode'
+        description: required if AccountKind=Foreign
+      employee_id:
+        type: integer
+      expires_at:
+        type: string
+      generate_card:
+        type: boolean
+      initial_balance:
+        minimum: 0
+        type: number
+      name:
+        type: string
+      subtype:
+        allOf:
+        - $ref: '#/definitions/model.Subtype'
+        description: required if AccountKind=Current
+    required:
+    - account_kind
+    - account_type
+    - client_id
+    - employee_id
+    - expires_at
+    - name
+    type: object
+  dto.CreateLoanRequest:
+    properties:
+      account_number:
+        type: string
+      amount:
+        type: number
+      loan_type_id:
+        type: integer
+      repayment_period:
+        description: Broj meseci
+        type: integer
+    required:
+    - account_number
+    - amount
+    - loan_type_id
+    - repayment_period
+    type: object
+  dto.CreateLoanResponse:
+    properties:
+      id:
+        type: integer
+      monthly_installment:
+        type: number
+      status:
+        $ref: '#/definitions/model.LoanRequestStatus'
+    type: object
+  dto.CreatePaymentRequest:
+    properties:
+      amount:
+        type: number
+      payer_account_number:
+        type: string
+      payment_code:
+        type: string
+      purpose:
+        type: string
+      recipient_account_number:
+        type: string
+      recipient_name:
+        type: string
+      reference_number:
+        type: string
+    required:
+    - amount
+    - payer_account_number
+    - recipient_account_number
+    - recipient_name
+    type: object
+  dto.CreatePaymentResponse:
+    properties:
+      id:
+        type: integer
+    type: object
+  dto.Installment:
+    properties:
+      amount:
+        type: number
+      number:
+        type: integer
+      status:
+        description: npr. "PAID", "UPCOMING"
+        type: string
+    type: object
+  dto.ListPaymentsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/dto.PaymentSummaryResponse'
+        type: array
+      page:
+        type: integer
+      page_size:
+        type: integer
+      total:
+        type: integer
+      total_pages:
+        type: integer
+    type: object
+  dto.ListTransfersResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/dto.TransferResponse'
+        type: array
+      page:
+        type: integer
+      page_size:
+        type: integer
+      total:
+        type: integer
+      total_pages:
+        type: integer
+    type: object
+  dto.LoanDetailsResponse:
+    properties:
+      amount:
+        type: number
+      currency:
+        $ref: '#/definitions/model.CurrencyCode'
+      id:
+        type: integer
+      installments:
+        items:
+          $ref: '#/definitions/dto.Installment'
+        type: array
+      interest_rate:
+        type: number
+      loan_type:
+        type: string
+      monthly_installment:
+        type: number
+      repayment_period:
+        type: integer
+      status:
+        $ref: '#/definitions/model.LoanRequestStatus'
+    type: object
+  dto.LoanResponse:
+    properties:
+      amount:
+        type: number
+      currency:
+        $ref: '#/definitions/model.CurrencyCode'
+      id:
+        type: integer
+      loan_type:
+        type: string
+      monthly_installment:
+        type: number
+      status:
+        $ref: '#/definitions/model.LoanRequestStatus'
+    type: object
+  dto.MessageResponse:
+    properties:
+      message:
+        type: string
+    type: object
+  dto.PaymentResponse:
+    properties:
+      amount:
+        type: number
+      created_at:
+        type: string
+      currency_code:
+        type: string
+      payer_account_number:
+        type: string
+      payment_code:
+        type: string
+      payment_id:
+        type: integer
+      purpose:
+        type: string
+      recipient_account_number:
+        type: string
+      recipient_name:
+        type: string
+      reference_number:
+        type: string
+      status:
+        type: string
+    type: object
+  dto.PaymentSummaryResponse:
+    properties:
+      amount:
+        type: number
+      created_at:
+        type: string
+      currency:
+        type: string
+      id:
+        type: integer
+      payer_account:
+        type: string
+      payment_code:
+        type: string
+      purpose:
+        type: string
+      recipient_account:
+        type: string
+      recipient_name:
+        type: string
+      status:
+        type: string
+    type: object
+  dto.RequestCardRequest:
+    properties:
+      account_number:
+        type: string
+      authorized_person:
+        $ref: '#/definitions/dto.AuthorizedPersonRequest'
+    required:
+    - account_number
+    type: object
+  dto.RequestLimitsChangeRequest:
     properties:
       daily_limit:
         type: number
@@ -208,35 +360,89 @@ definitions:
     - daily_limit
     - monthly_limit
     type: object
-  banking-service_internal_dto.RequestLimitsChangeResponse:
+  dto.TransferRequest:
     properties:
-      code:
+      amount:
+        type: number
+      from_account:
         type: string
+      to_account:
+        type: string
+    required:
+    - amount
+    - from_account
+    - to_account
     type: object
-  banking-service_internal_dto.UpdateAccountNameRequest:
+  dto.TransferResponse:
+    properties:
+      commission:
+        type: number
+      created_at:
+        type: string
+      exchange_rate:
+        type: number
+      final_amount:
+        type: number
+      from_account_number:
+        type: string
+      initial_amount:
+        type: number
+      to_account_number:
+        type: string
+      transaction_id:
+        type: integer
+      transfer_id:
+        type: integer
+    type: object
+  dto.UpdateAccountNameRequest:
     properties:
       name:
         type: string
     required:
     - name
     type: object
-  banking-service_internal_model.AccountKind:
+  dto.VerifyPaymentRequest:
+    properties:
+      code:
+        type: string
+    required:
+    - code
+    type: object
+  dto.VerifyPaymentResponse:
+    properties:
+      id:
+        type: integer
+    type: object
+  errors.AppError:
+    properties:
+      message:
+        type: string
+      status:
+        type: string
+      timestamp:
+        type: string
+    type: object
+  model.AccountKind:
     enum:
     - Current
     - Foreign
+    - Internal
     type: string
     x-enum-varnames:
     - AccountKindCurrent
     - AccountKindForeign
-  banking-service_internal_model.AccountType:
+    - AccountKindInternal
+  model.AccountType:
     enum:
     - Personal
     - Business
+    - Bank
     type: string
     x-enum-varnames:
     - AccountTypePersonal
     - AccountTypeBusiness
-  banking-service_internal_model.CurrencyCode:
+    - AccountTypeBank
+  model.CurrencyCode:
     enum:
     - EUR
     - USD
@@ -256,7 +462,17 @@ definitions:
     - CAD
     - AUD
     - RSD
-  banking-service_internal_model.Subtype:
+  model.LoanRequestStatus:
+    enum:
+    - PENDING
+    - APPROVED
+    - REJECTED
+    type: string
+    x-enum-varnames:
+    - LoanRequestPending
+    - LoanRequestApproved
+    - LoanRequestRejected
+  model.Subtype:
     enum:
     - Standard
     - Savings
@@ -278,39 +494,6 @@ definitions:
     - SubtypeLLC
     - SubtypeJointStock
     - SubtypeFoundation
-  dto.ConfirmCardRequest:
-    properties:
-      account_number:
-        type: string
-      confirmation_code:
-        type: string
-    required:
-    - account_number
-    - confirmation_code
-    type: object
-  dto.MessageResponse:
-    properties:
-      message:
-        type: string
-    type: object
-  dto.RequestCardRequest:
-    properties:
-      account_number:
-        type: string
-      authorized_person:
-        $ref: '#/definitions/dto.AuthorizedPersonRequest'
-    required:
-    - account_number
-    type: object
-  errors.AppError:
-    properties:
-      message:
-        type: string
-      status:
-        type: string
-      timestamp:
-        type: string
-    type: object
 info:
   contact: {}
   description: API for managing accounts, balances, and banking operations.
@@ -319,38 +502,59 @@ info:
 paths:
   /api/accounts:
     get:
-      description: Returns all active accounts belonging to the authenticated client
-  /api/accounts/{accountId}/cards:
-    get:
-      description: Returns cards for the specified account. Clients can access only
-        their own accounts, while employees can access any account.
+      description: Returns a paginated list of all accounts. Employee access only.
+        Supports filtering by client, account type, kind, status and currency.
       parameters:
-      - description: Account number
-        in: path
-        name: accountId
-        required: true
+      - description: Filter by client ID
+        in: query
+        name: client_id
+        type: integer
+      - description: Filter by account type
+        in: query
+        name: account_type
         type: string
+      - description: Filter by account kind
+        in: query
+        name: account_kind
+        type: string
+      - description: Filter by status
+        in: query
+        name: status
+        type: string
+      - description: Filter by currency ID
+        in: query
+        name: currency_id
+        type: integer
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/banking-service_internal_dto.AccountSummaryResponse'
-            type: array
+            type: object
         "400":
           description: Bad Request
           schema:
             $ref: '#/definitions/errors.AppError'
-            $ref: '#/definitions/dto.AccountCardsResponse'
         "401":
           description: Unauthorized
           schema:
             $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
       security:
       - BearerAuth: []
-      summary: List client accounts
+      summary: List all accounts
       tags:
       - accounts
     post:
@@ -365,18 +569,16 @@ paths:
         name: account
         required: true
         schema:
-          $ref: '#/definitions/banking-service_internal_dto.CreateAccountRequest'
+          $ref: '#/definitions/dto.CreateAccountRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/banking-service_internal_dto.AccountResponse'
+            $ref: '#/definitions/dto.AccountResponse'
         "400":
           description: Bad Request
-        "403":
-          description: Forbidden
           schema:
             $ref: '#/definitions/errors.AppError'
         "404":
@@ -392,21 +594,6 @@ paths:
       summary: Create a new bank account
       tags:
       - accounts
-  /api/accounts/{accountNumber}:
-    get:
-      description: Returns full details for a specific account owned by the authenticated
-        client
-      parameters:
-      - description: Account number
-        in: path
-        name: accountNumber
-        required: true
-        type: string
-      security:
-      - BearerAuth: []
-      summary: List cards for an account
-      tags:
-      - cards
   /api/cards/{cardId}/block:
     put:
       description: Blocks a card. Clients can block only their own cards, while employees
@@ -423,7 +610,6 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/banking-service_internal_dto.AccountResponse'
             $ref: '#/definitions/dto.CardResponse'
         "400":
           description: Bad Request
@@ -443,28 +629,6 @@ paths:
             $ref: '#/definitions/errors.AppError'
       security:
       - BearerAuth: []
-      summary: Get account details
-      tags:
-      - accounts
-  /api/accounts/{accountNumber}/limits:
-    put:
-      consumes:
-      - application/json
-      description: Confirms a pending limit change request using the verification
-        code from the mobile app
-      parameters:
-      - description: Account number
-        in: path
-        name: accountNumber
-        required: true
-        type: string
-      - description: Verification code, you can use 1234 for testing but still needs
-          request to be made first
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/banking-service_internal_dto.ConfirmLimitsChangeRequest'
       summary: Block a card
       tags:
       - cards
@@ -503,27 +667,6 @@ paths:
             $ref: '#/definitions/errors.AppError'
       security:
       - BearerAuth: []
-      summary: Confirm account limit change
-      tags:
-      - accounts
-  /api/accounts/{accountNumber}/limits/request:
-    post:
-      consumes:
-      - application/json
-      description: Initiates a limit change request for an account. Sends a verification
-        code for confirmation via mobile app, temporarily returned in body as code.
-      parameters:
-      - description: Account number
-        in: path
-        name: accountNumber
-        required: true
-        type: string
-      - description: New daily and monthly limits
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/banking-service_internal_dto.RequestLimitsChangeRequest'
       summary: Deactivate a card
       tags:
       - cards
@@ -542,7 +685,6 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/banking-service_internal_dto.RequestLimitsChangeResponse'
             $ref: '#/definitions/dto.CardResponse'
         "400":
           description: Bad Request
@@ -562,22 +704,6 @@ paths:
             $ref: '#/definitions/errors.AppError'
       security:
       - BearerAuth: []
-      summary: Request account limit change
-      tags:
-      - accounts
-  /api/accounts/{accountNumber}/name:
-    put:
-      consumes:
-      - application/json
-      description: Updates the display name of an account owned by the authenticated
-        client
-      parameters:
-      - description: Account number
-        in: path
-        name: accountNumber
-        required: true
-        type: string
-      - description: New account name
       summary: Unblock a card
       tags:
       - cards
@@ -593,7 +719,6 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/banking-service_internal_dto.UpdateAccountNameRequest'
           $ref: '#/definitions/dto.RequestCardRequest'
       produces:
       - application/json
@@ -618,16 +743,245 @@ paths:
           description: Not Found
           schema:
             $ref: '#/definitions/errors.AppError'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Request a new card
+      tags:
+      - cards
+  /api/cards/request/confirm:
+    post:
+      consumes:
+      - application/json
+      description: Confirms a pending card request using the confirmation code and
+        creates the card.
+      parameters:
+      - description: Confirmation payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.ConfirmCardRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.CardResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Confirm a card request
+      tags:
+      - cards
+  /api/clients/{clientId}/accounts/{accountNumber}/cards:
+    get:
+      description: Returns cards for the specified account. Clients can access only
+        their own accounts, while employees can access any account.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Account number
+        in: path
+        name: accountNumber
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.AccountCardsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: List cards for an account
+      tags:
+      - cards
+  /api/clients/{clientId}/accounts/{accountNumber}/limits:
+    put:
+      consumes:
+      - application/json
+      description: Confirms a pending limit change request using the verification
+        code from the mobile app
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Account number
+        in: path
+        name: accountNumber
+        required: true
+        type: string
+      - description: Verification code generated in mobile app
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.ConfirmLimitsChangeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Confirm account limit change
+      tags:
+      - accounts
+  /api/clients/{clientId}/accounts/{accountNumber}/limits/request:
+    post:
+      consumes:
+      - application/json
+      description: Initiates a limit change request for an account. Confirmation uses
+        TOTP code generated in the mobile app.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Account number
+        in: path
+        name: accountNumber
+        required: true
+        type: string
+      - description: New daily and monthly limits
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.RequestLimitsChangeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Request account limit change
+      tags:
+      - accounts
+  /api/clients/{clientId}/accounts/{accountNumber}/name:
+    put:
+      consumes:
+      - application/json
+      description: Updates the display name of an account owned by the authenticated
+        client
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Account number
+        in: path
+        name: accountNumber
+        required: true
+        type: string
+      - description: New account name
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.UpdateAccountNameRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
       security:
       - BearerAuth: []
       summary: Update account name
       tags:
       - accounts
-  /api/accounts/{accountNumber}/payments:
+  /api/clients/{clientId}/accounts/{accountNumber}/payments:
     get:
       description: Returns a paginated list of payments for an account, filterable
-        by status, date range, and amount. Only the account owner can access this.
+        by status, date range, and amount. Clients can access only their own accounts,
+        employees can access any.
       parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
       - description: Account number
         in: path
         name: accountNumber
@@ -670,36 +1024,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/banking-service_internal_dto.ListPaymentsResponse'
-        "409":
-          description: Conflict
-          schema:
-            $ref: '#/definitions/errors.AppError'
-      security:
-      - BearerAuth: []
-      summary: Request a new card
-      tags:
-      - cards
-  /api/cards/request/confirm:
-    post:
-      consumes:
-      - application/json
-      description: Confirms a pending card request using the confirmation code and
-        creates the card.
-      parameters:
-      - description: Confirmation payload
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/dto.ConfirmCardRequest'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/dto.CardResponse'
+            $ref: '#/definitions/dto.ListPaymentsResponse'
         "400":
           description: Bad Request
           schema:
@@ -717,19 +1042,484 @@ paths:
       summary: List account payments
       tags:
       - payments
-        "404":
-          description: Not Found
+  /api/clients/{clientId}/loans:
+    get:
+      description: Returns a list of loans for a client. Supports sorting by amount.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: 'Sort by amount: ''asc'' or ''desc'''
+        in: query
+        name: sort
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/dto.LoanResponse'
+            type: array
+        "400":
+          description: Bad Request
           schema:
             $ref: '#/definitions/errors.AppError'
-        "409":
-          description: Conflict
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "500":
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/errors.AppError'
       security:
       - BearerAuth: []
-      summary: Confirm a card request
+      summary: List client loans
       tags:
-      - cards
+      - loans
+  /api/clients/{clientId}/loans/{loanId}:
+    get:
+      description: Returns detailed loan information including the repayment schedule.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Loan ID
+        in: path
+        name: loanId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.LoanDetailsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Get loan details
+      tags:
+      - loans
+  /api/clients/{clientId}/loans/request:
+    post:
+      consumes:
+      - application/json
+      description: Client submits a loan request. Validates repayment period and currency,
+        and calculates the monthly installment based on bank margin.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Loan request data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CreateLoanRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.CreateLoanResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Submit a loan request
+      tags:
+      - loans
+  /api/clients/{clientId}/payments:
+    get:
+      description: Returns a paginated list of all payments for a client. Supports
+        filtering by status, date range, and amount.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Filter by status (processing, completed, rejected)
+        in: query
+        name: status
+        type: string
+      - description: Filter from date (YYYY-MM-DD)
+        in: query
+        name: start_date
+        type: string
+      - description: Filter to date (YYYY-MM-DD)
+        in: query
+        name: end_date
+        type: string
+      - description: Minimum amount filter
+        in: query
+        name: min_amount
+        type: number
+      - description: Maximum amount filter
+        in: query
+        name: max_amount
+        type: number
+      - description: Page number
+        in: query
+        minimum: 1
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        maximum: 100
+        minimum: 1
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ListPaymentsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: List all client payments
+      tags:
+      - payments
+    post:
+      consumes:
+      - application/json
+      description: Creates a new payment from the request body. Only the authenticated
+        client can create payments.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Payment data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CreatePaymentRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.CreatePaymentResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Create a new payment
+      tags:
+      - payments
+  /api/clients/{clientId}/payments/{id}:
+    get:
+      description: Returns payment details by ID. Clients can only access their own
+        payments, employees can access any.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Payment ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.PaymentResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Get payment details
+      tags:
+      - payments
+  /api/clients/{clientId}/payments/{id}/receipt:
+    get:
+      description: Generates and returns a PDF receipt for a completed payment.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Payment ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/pdf
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Download payment receipt
+      tags:
+      - payments
+  /api/clients/{clientId}/payments/{id}/verify:
+    post:
+      consumes:
+      - application/json
+      description: Confirms a payment using a verification code. Only the client who
+        created the payment can verify it.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Payment ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Verification code
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.VerifyPaymentRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.VerifyPaymentResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Verify a payment
+      tags:
+      - payments
+  /api/clients/{clientId}/transfers:
+    get:
+      description: Returns transfer history for a client, newest first. Supports pagination.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Page number
+        in: query
+        minimum: 1
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        maximum: 100
+        minimum: 1
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ListTransfersResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Get client transfer history
+      tags:
+      - transfers
+    post:
+      consumes:
+      - application/json
+      description: Executes transfer between two authenticated-client accounts and
+        persists transaction and transfer records atomically.
+      parameters:
+      - description: Client ID
+        in: path
+        name: clientId
+        required: true
+        type: integer
+      - description: Transfer details
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.TransferRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.TransferResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Execute an internal transfer
+      tags:
+      - transfers
   /api/health:
     get:
       description: Returns service health status
@@ -745,6 +1535,117 @@ paths:
       summary: Health check
       tags:
       - health
+  /api/loan-requests:
+    get:
+      description: Returns a paginated list of all loan requests. Employee access
+        only.
+      parameters:
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: List loan requests
+      tags:
+      - loan-requests
+  /api/loan-requests/{id}/approve:
+    patch:
+      description: Approves a pending loan request. Employee access only.
+      parameters:
+      - description: Loan request ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Approve a loan request
+      tags:
+      - loan-requests
+  /api/loan-requests/{id}/reject:
+    patch:
+      description: Rejects a pending loan request. Employee access only.
+      parameters:
+      - description: Loan request ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Reject a loan request
+      tags:
+      - loan-requests
 securityDefinitions:
   BearerAuth:
     description: JWT Authorization header using the Bearer scheme.

--- a/services/banking-service/internal/handler/account_handler.go
+++ b/services/banking-service/internal/handler/account_handler.go
@@ -47,6 +47,24 @@ func (h *AccountHandler) Create(c *gin.Context) {
 	c.JSON(http.StatusCreated, dto.ToAccountResponse(account))
 }
 
+// ListAccounts godoc
+// @Summary List all accounts
+// @Description Returns a paginated list of all accounts. Employee access only. Supports filtering by client, account type, kind, status and currency.
+// @Tags accounts
+// @Produce json
+// @Param client_id query int false "Filter by client ID"
+// @Param account_type query string false "Filter by account type"
+// @Param account_kind query string false "Filter by account kind"
+// @Param status query string false "Filter by status"
+// @Param currency_id query int false "Filter by currency ID"
+// @Param page query int false "Page number"
+// @Param page_size query int false "Page size"
+// @Success 200 {object} object
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/accounts [get]
 func (h *AccountHandler) ListAccounts(c *gin.Context) {
 	var req dto.ListAccountsQuery
 
@@ -54,12 +72,15 @@ func (h *AccountHandler) ListAccounts(c *gin.Context) {
 		c.Error(errors.BadRequestErr(err.Error()))
 		return
 	}
+
 	if req.Page < 0 {
 		req.Page = 1
 	}
+
 	if req.PageSize < 0 {
 		req.PageSize = 10
 	}
+
 	accounts, total, err := h.service.GetAllAccounts(c.Request.Context(), &req)
 	if err != nil {
 		c.Error(err)
@@ -155,6 +176,7 @@ func (h *AccountHandler) GetAccountDetails(c *gin.Context) {
 // @Tags accounts
 // @Accept json
 // @Produce json
+// @Param clientId path int true "Client ID"
 // @Param accountNumber path string true "Account number"
 // @Param request body dto.UpdateAccountNameRequest true "New account name"
 // @Success 200
@@ -162,7 +184,7 @@ func (h *AccountHandler) GetAccountDetails(c *gin.Context) {
 // @Failure 403 {object} errors.AppError
 // @Failure 404 {object} errors.AppError
 // @Security BearerAuth
-// @Router /api/clients/{clientId}/accounts/{accountNumber}/name [get]
+// @Router /api/clients/{clientId}/accounts/{accountNumber}/name [put]
 func (h *AccountHandler) UpdateAccountName(c *gin.Context) {
 	clientId, ok := GetParamUint(c, "clientId")
 	if !ok {
@@ -191,6 +213,7 @@ func (h *AccountHandler) UpdateAccountName(c *gin.Context) {
 // @Tags accounts
 // @Accept json
 // @Produce json
+// @Param clientId path int true "Client ID"
 // @Param accountNumber path string true "Account number"
 // @Param request body dto.RequestLimitsChangeRequest true "New daily and monthly limits"
 // @Success 200
@@ -227,6 +250,7 @@ func (h *AccountHandler) RequestLimitsChange(c *gin.Context) {
 // @Tags accounts
 // @Accept json
 // @Produce json
+// @Param clientId path int true "Client ID"
 // @Param accountNumber path string true "Account number"
 // @Param request body dto.ConfirmLimitsChangeRequest true "Verification code generated in mobile app"
 // @Success 200

--- a/services/banking-service/internal/handler/card_handler.go
+++ b/services/banking-service/internal/handler/card_handler.go
@@ -103,15 +103,16 @@ func (h *CardHandler) ConfirmCardRequest(c *gin.Context) {
 // @Description Returns cards for the specified account. Clients can access only their own accounts, while employees can access any account.
 // @Tags cards
 // @Produce json
-// @Param accountId path string true "Account number"
+// @Param clientId path int true "Client ID"
+// @Param accountNumber path string true "Account number"
 // @Success 200 {object} dto.AccountCardsResponse
 // @Failure 401 {object} errors.AppError
 // @Failure 403 {object} errors.AppError
 // @Failure 404 {object} errors.AppError
 // @Security BearerAuth
-// @Router /api/accounts/{accountId}/cards [get]
+// @Router /api/clients/{clientId}/accounts/{accountNumber}/cards [get]
 func (h *CardHandler) ListCardsByAccount(c *gin.Context) {
-	accountNumber := c.Param("accountId")
+	accountNumber := c.Param("accountNumber")
 
 	result, err := h.service.ListCardsForAccount(c.Request.Context(), accountNumber)
 	if err != nil {

--- a/services/banking-service/internal/handler/loan_handler.go
+++ b/services/banking-service/internal/handler/loan_handler.go
@@ -19,21 +19,22 @@ func NewLoanHandler(loanService *service.LoanService) *LoanHandler {
 	return &LoanHandler{loanService: loanService}
 }
 
-// SubmitLoanRequest godocExpand commentComment on line R23
-// @Summary      Podnošenje zahteva za kredit
-// @Description  Klijent podnosi zahtev za kredit. Vrši se validacija perioda otplate i valute, i računa se mesečna rata na osnovu marže banke.
-// @Tags         loans
-// @Accept       json
-// @Produce      json
-// @Param        request body dto.CreateLoanRequest true "Podaci za zahtev kredita"
-// @Success      201  {object}  dto.CreateLoanResponse
-// @Failure      400  {object}  errors.AppError "Nevalidni podaci, valuta se ne poklapa ili los period otplate"
-// @Failure      401  {object}  errors.AppError "Korisnik nije ulogovan"
-// @Failure      403  {object}  errors.AppError "Račun ne pripada klijentu"
-// @Failure      404  {object}  errors.AppError "Kredit nije pronađen"
-// @Failure      500  {object}  errors.AppError "Greška na serveru"
-// @Router       /api/loans/request [post]
-// @Security     BearerAuth
+// SubmitLoanRequest godoc
+// @Summary Submit a loan request
+// @Description Client submits a loan request. Validates repayment period and currency, and calculates the monthly installment based on bank margin.
+// @Tags loans
+// @Accept json
+// @Produce json
+// @Param clientId path int true "Client ID"
+// @Param request body dto.CreateLoanRequest true "Loan request data"
+// @Success 201 {object} dto.CreateLoanResponse
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Failure 404 {object} errors.AppError
+// @Failure 500 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients/{clientId}/loans/request [post]
 func (h *LoanHandler) SubmitLoanRequest(c *gin.Context) {
 	var req dto.CreateLoanRequest
 
@@ -42,7 +43,7 @@ func (h *LoanHandler) SubmitLoanRequest(c *gin.Context) {
 		return
 	}
 
-	clientID, err := strconv.ParseUint(c.Param("client_id"), 10, 64)
+	clientID, err := strconv.ParseUint(c.Param("clientId"), 10, 64)
 	if err != nil {
 		c.Error(errors.BadRequestErr("invalid client id"))
 		return
@@ -59,21 +60,21 @@ func (h *LoanHandler) SubmitLoanRequest(c *gin.Context) {
 }
 
 // GetLoans godoc
-// @Summary      Pregled svih kredita klijenta
-// @Description  Vraća listu kredita. Podržava sortiranje po iznosu.
-// @Tags         loans
-// @Produce      json
-// @Param        sort query string false "Sortiraj po iznosu: 'asc' ili 'desc'"
-// @Success      200  {array}   dto.LoanResponse
-// @Router       /api/loans [get]
-// @Security     BearerAuth
-// @Failure      400  {object}  errors.AppError "Nevalidni podaci, valuta se ne poklapa ili los period otplate"
-// @Failure      401  {object}  errors.AppError "Korisnik nije ulogovan"
-// @Failure      403  {object}  errors.AppError "Račun ne pripada klijentu"
-// @Failure      404  {object}  errors.AppError "Kredit nije pronađen"
-// @Failure      500  {object}  errors.AppError "Greška na serveru"
+// @Summary List client loans
+// @Description Returns a list of loans for a client. Supports sorting by amount.
+// @Tags loans
+// @Produce json
+// @Param clientId path int true "Client ID"
+// @Param sort query string false "Sort by amount: 'asc' or 'desc'"
+// @Success 200 {array} dto.LoanResponse
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Failure 500 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients/{clientId}/loans [get]
 func (h *LoanHandler) GetLoans(c *gin.Context) {
-	clientID, err := strconv.ParseUint(c.Param("client_id"), 10, 64)
+	clientID, err := strconv.ParseUint(c.Param("clientId"), 10, 64)
 	if err != nil {
 		c.Error(errors.BadRequestErr("invalid client id"))
 		return
@@ -92,27 +93,28 @@ func (h *LoanHandler) GetLoans(c *gin.Context) {
 }
 
 // GetLoanByID godoc
-// @Summary      Detalji kredita
-// @Description  Vraća detaljne informacije o kreditu uključujući plan otplate (rate).
-// @Tags         loans
-// @Produce      json
-// @Param        id   path      int  true  "ID kredita"
-// @Success      200  {object}  dto.LoanDetailsResponse
-// @Router       /api/loans/{id} [get]
-// @Security     BearerAuth
-// @Failure      400  {object}  errors.AppError "Nevalidni podaci, valuta se ne poklapa ili los period otplate"
-// @Failure      401  {object}  errors.AppError "Korisnik nije ulogovan"
-// @Failure      403  {object}  errors.AppError "Račun ne pripada klijentu"
-// @Failure      404  {object}  errors.AppError "Kredit nije pronađen"
-// @Failure      500  {object}  errors.AppError "Greška na serveru"
+// @Summary Get loan details
+// @Description Returns detailed loan information including the repayment schedule.
+// @Tags loans
+// @Produce json
+// @Param clientId path int true "Client ID"
+// @Param loanId path int true "Loan ID"
+// @Success 200 {object} dto.LoanDetailsResponse
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Failure 404 {object} errors.AppError
+// @Failure 500 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients/{clientId}/loans/{loanId} [get]
 func (h *LoanHandler) GetLoanByID(c *gin.Context) {
-	clientID, err := strconv.ParseUint(c.Param("client_id"), 10, 64)
+	clientID, err := strconv.ParseUint(c.Param("clientId"), 10, 64)
 	if err != nil {
 		c.Error(errors.BadRequestErr("invalid client id"))
 		return
 	}
 
-	loanID, err := strconv.ParseUint(c.Param("loan_id"), 10, 64)
+	loanID, err := strconv.ParseUint(c.Param("loanId"), 10, 64)
 	if err != nil {
 		c.Error(errors.BadRequestErr("invalid loan id"))
 		return
@@ -120,13 +122,26 @@ func (h *LoanHandler) GetLoanByID(c *gin.Context) {
 
 	details, err := h.loanService.GetLoanDetails(c.Request.Context(), uint(clientID), uint(loanID))
 	if err != nil {
-		c.Error(errors.NotFoundErr(err.Error()))
+		c.Error(err)
 		return
 	}
 
 	c.JSON(http.StatusOK, details)
 }
 
+// ListLoanRequests godoc
+// @Summary List loan requests
+// @Description Returns a paginated list of all loan requests. Employee access only.
+// @Tags loan-requests
+// @Produce json
+// @Param page query int false "Page number"
+// @Param page_size query int false "Page size"
+// @Success 200 {object} object
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/loan-requests [get]
 func (h *LoanHandler) ListLoanRequests(c *gin.Context) {
 	var query dto.ListLoanRequestsQuery
 
@@ -155,6 +170,19 @@ func (h *LoanHandler) ListLoanRequests(c *gin.Context) {
 		"page_size": query.PageSize,
 	})
 }
+// ApproveLoanRequest godoc
+// @Summary Approve a loan request
+// @Description Approves a pending loan request. Employee access only.
+// @Tags loan-requests
+// @Produce json
+// @Param id path int true "Loan request ID"
+// @Success 200 {object} object
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Failure 404 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/loan-requests/{id}/approve [patch]
 func (h *LoanHandler) ApproveLoanRequest(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
@@ -170,6 +198,19 @@ func (h *LoanHandler) ApproveLoanRequest(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Loan request approved successfully"})
 }
 
+// RejectLoanRequest godoc
+// @Summary Reject a loan request
+// @Description Rejects a pending loan request. Employee access only.
+// @Tags loan-requests
+// @Produce json
+// @Param id path int true "Loan request ID"
+// @Success 200 {object} object
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Failure 404 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/loan-requests/{id}/reject [patch]
 func (h *LoanHandler) RejectLoanRequest(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {

--- a/services/banking-service/internal/handler/payment_handler.go
+++ b/services/banking-service/internal/handler/payment_handler.go
@@ -21,6 +21,20 @@ func NewPaymentHandler(paymentService *service.PaymentService, accountService *s
 	return &PaymentHandler{service: paymentService, accountService: accountService}
 }
 
+// CreatePayment godoc
+// @Summary Create a new payment
+// @Description Creates a new payment from the request body. Only the authenticated client can create payments.
+// @Tags payments
+// @Accept json
+// @Produce json
+// @Param clientId path int true "Client ID"
+// @Param request body dto.CreatePaymentRequest true "Payment data"
+// @Success 200 {object} dto.CreatePaymentResponse
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients/{clientId}/payments [post]
 func (h *PaymentHandler) CreatePayment(c *gin.Context) {
 	var req dto.CreatePaymentRequest
 
@@ -40,6 +54,20 @@ func (h *PaymentHandler) CreatePayment(c *gin.Context) {
 	})
 }
 
+// GetPaymentByID godoc
+// @Summary Get payment details
+// @Description Returns payment details by ID. Clients can only access their own payments, employees can access any.
+// @Tags payments
+// @Produce json
+// @Param clientId path int true "Client ID"
+// @Param id path int true "Payment ID"
+// @Success 200 {object} dto.PaymentResponse
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Failure 404 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients/{clientId}/payments/{id} [get]
 func (h *PaymentHandler) GetPaymentByID(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
@@ -56,6 +84,20 @@ func (h *PaymentHandler) GetPaymentByID(c *gin.Context) {
 	c.JSON(http.StatusOK, dto.ToPaymentResponse(payment))
 }
 
+// GetReceipt godoc
+// @Summary Download payment receipt
+// @Description Generates and returns a PDF receipt for a completed payment.
+// @Tags payments
+// @Produce application/pdf
+// @Param clientId path int true "Client ID"
+// @Param id path int true "Payment ID"
+// @Success 200 {file} file
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Failure 404 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients/{clientId}/payments/{id}/receipt [get]
 func (h *PaymentHandler) GetReceipt(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
@@ -73,6 +115,22 @@ func (h *PaymentHandler) GetReceipt(c *gin.Context) {
 	c.Data(http.StatusOK, "application/pdf", pdfBytes)
 }
 
+// VerifyPayment godoc
+// @Summary Verify a payment
+// @Description Confirms a payment using a verification code. Only the client who created the payment can verify it.
+// @Tags payments
+// @Accept json
+// @Produce json
+// @Param clientId path int true "Client ID"
+// @Param id path int true "Payment ID"
+// @Param request body dto.VerifyPaymentRequest true "Verification code"
+// @Success 200 {object} dto.VerifyPaymentResponse
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Failure 404 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients/{clientId}/payments/{id}/verify [post]
 func (h *PaymentHandler) VerifyPayment(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
@@ -104,9 +162,10 @@ func (h *PaymentHandler) VerifyPayment(c *gin.Context) {
 
 // GetAccountPayments godoc
 // @Summary List account payments
-// @Description Returns a paginated list of payments for an account, filterable by status, date range, and amount. Only the account owner can access this.
+// @Description Returns a paginated list of payments for an account, filterable by status, date range, and amount. Clients can access only their own accounts, employees can access any.
 // @Tags payments
 // @Produce json
+// @Param clientId path int true "Client ID"
 // @Param accountNumber path string true "Account number"
 // @Param status query string false "Filter by status (processing, completed, rejected)"
 // @Param start_date query string false "Filter from date (YYYY-MM-DD)"
@@ -117,9 +176,10 @@ func (h *PaymentHandler) VerifyPayment(c *gin.Context) {
 // @Param page_size query int false "Page size" minimum(1) maximum(100)
 // @Success 200 {object} dto.ListPaymentsResponse
 // @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
 // @Failure 403 {object} errors.AppError
 // @Security BearerAuth
-// @Router /api/accounts/{accountNumber}/payments [get]
+// @Router /api/clients/{clientId}/accounts/{accountNumber}/payments [get]
 func (h *PaymentHandler) GetAccountPayments(c *gin.Context) {
 	valStr := c.Param("clientId")
 
@@ -177,6 +237,25 @@ func (h *PaymentHandler) GetAccountPayments(c *gin.Context) {
 }
 
 
+// GetClientPayments godoc
+// @Summary List all client payments
+// @Description Returns a paginated list of all payments for a client. Supports filtering by status, date range, and amount.
+// @Tags payments
+// @Produce json
+// @Param clientId path int true "Client ID"
+// @Param status query string false "Filter by status (processing, completed, rejected)"
+// @Param start_date query string false "Filter from date (YYYY-MM-DD)"
+// @Param end_date query string false "Filter to date (YYYY-MM-DD)"
+// @Param min_amount query number false "Minimum amount filter"
+// @Param max_amount query number false "Maximum amount filter"
+// @Param page query int false "Page number" minimum(1)
+// @Param page_size query int false "Page size" minimum(1) maximum(100)
+// @Success 200 {object} dto.ListPaymentsResponse
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients/{clientId}/payments [get]
 func (h *PaymentHandler) GetClientPayments(c *gin.Context) {
 	valStr := c.Param("clientId")
 

--- a/services/banking-service/internal/handler/transfer_handler.go
+++ b/services/banking-service/internal/handler/transfer_handler.go
@@ -24,6 +24,7 @@ func NewTransferHandler(service *service.TransferService) *TransferHandler {
 // @Tags transfers
 // @Accept json
 // @Produce json
+// @Param clientId path int true "Client ID"
 // @Param request body dto.TransferRequest true "Transfer details"
 // @Success 201 {object} dto.TransferResponse
 // @Failure 400 {object} errors.AppError
@@ -32,7 +33,7 @@ func NewTransferHandler(service *service.TransferService) *TransferHandler {
 // @Failure 404 {object} errors.AppError
 // @Failure 500 {object} errors.AppError
 // @Security BearerAuth
-// @Router /api/transfers [post]
+// @Router /api/clients/{clientId}/transfers [post]
 func (h *TransferHandler) ExecuteTransfer(c *gin.Context) {
 	var req dto.TransferRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/services/banking-service/internal/server/rest.go
+++ b/services/banking-service/internal/server/rest.go
@@ -45,7 +45,13 @@ func NewServer(
 		accountHandler,
 		companyHandler,
 		transferHandler,
-		payeeHandler, exchangeHandler, paymentHandler, cardHandler, loanHandler, verifier, permissions,
+		payeeHandler,
+		exchangeHandler,
+		paymentHandler,
+		cardHandler,
+		loanHandler,
+		verifier,
+		permissions,
 	)
 
 	server := &http.Server{
@@ -94,13 +100,17 @@ func SetupRoutes(
 	{
 		api.GET("/health", healthHandler.Health)
 
+		exchange := api.Group("/exchange")
+		{
+			exchange.GET("/rates", exchangeHandler.GetRates)
+			exchange.GET("/calculate", exchangeHandler.Calculate)
+		}
+
 		accounts := api.Group("/accounts")
 		accounts.Use(auth.Middleware(verifier, permissions))
 		{
-			accounts.POST("", accountHandler.Create)
-			accounts.GET("/:accountId/cards", auth.RequireIdentityType(auth.IdentityClient, auth.IdentityEmployee), cardHandler.ListCardsByAccount)
-			accounts.GET("", auth.RequireIdentityType(auth.IdentityClient, auth.IdentityEmployee), accountHandler.ListAccounts)
-			//TODO employee list all accounts here?
+			accounts.GET("", auth.RequireIdentityType(auth.IdentityEmployee), accountHandler.ListAccounts)
+			accounts.POST("", auth.RequireIdentityType(auth.IdentityEmployee), accountHandler.Create)
 		}
 
 		client := api.Group("/clients/:clientId")
@@ -108,36 +118,55 @@ func SetupRoutes(
 		{
 			clientAccounts := client.Group("/accounts")
 			{
-				clientAccounts.GET("", accountHandler.GetClientAccounts)
-				clientAccounts.GET("/:accountNumber", accountHandler.GetAccountDetails)
-				clientAccounts.GET("/:accountNumber/payments", paymentHandler.GetAccountPayments)
-				clientAccounts.PUT("/:accountNumber/name", accountHandler.UpdateAccountName)
-				clientAccounts.POST("/:accountNumber/limits/request", accountHandler.RequestLimitsChange)
-				clientAccounts.PUT("/:accountNumber/limits", accountHandler.ConfirmLimitsChange)
+				clientAccounts.GET("", auth.RequireClientSelf("clientId", true), accountHandler.GetClientAccounts)
+
+				account := clientAccounts.Group("/:accountNumber")
+				{
+					account.GET("", auth.RequireClientSelf("clientId", true), accountHandler.GetAccountDetails)
+					account.GET("/cards", auth.RequireClientSelf("clientId", true), cardHandler.ListCardsByAccount)
+					account.GET("/payments", auth.RequireClientSelf("clientId", true), paymentHandler.GetAccountPayments)
+					account.PUT("/name", auth.RequireClientSelf("clientId", false), accountHandler.UpdateAccountName)
+					account.PUT("/limits", auth.RequireClientSelf("clientId", false), accountHandler.ConfirmLimitsChange)
+					account.POST("/limits/request", auth.RequireClientSelf("clientId", false), accountHandler.RequestLimitsChange)
+				}
 			}
+
 			clientPayments := client.Group("/payments")
 			{
-				clientPayments.GET("", paymentHandler.GetClientPayments)
-				clientPayments.GET("/:id", paymentHandler.GetPaymentByID)
-				clientPayments.GET("/:id/receipt", paymentHandler.GetReceipt)
-				clientPayments.POST("", paymentHandler.CreatePayment)
-				clientPayments.POST("/:id/verify", paymentHandler.VerifyPayment)
+				clientPayments.GET("", auth.RequireClientSelf("clientId", true), paymentHandler.GetClientPayments)
+				clientPayments.POST("", auth.RequireClientSelf("clientId", false), paymentHandler.CreatePayment)
+				clientPayments.GET("/:id", auth.RequireClientSelf("clientId", true), paymentHandler.GetPaymentByID)
+				clientPayments.GET("/:id/receipt", auth.RequireClientSelf("clientId", true), paymentHandler.GetReceipt)
+				clientPayments.POST("/:id/verify", auth.RequireClientSelf("clientId", false), paymentHandler.VerifyPayment)
+			}
+
+			clientLoans := client.Group("/loans")
+			{
+				clientLoans.GET("", auth.RequireClientSelf("clientId", true), loanHandler.GetLoans)
+				clientLoans.GET("/:loanId", auth.RequireClientSelf("clientId", true), loanHandler.GetLoanByID)
+				clientLoans.POST("/request", auth.RequireClientSelf("clientId", false), loanHandler.SubmitLoanRequest)
+			}
+
+			clientTransfers := client.Group("/transfers")
+			{
+				clientTransfers.GET("", auth.RequireClientSelf("clientId", true), transferHandler.GetTransferHistory)
+				clientTransfers.POST("", auth.RequireClientSelf("clientId", false), transferHandler.ExecuteTransfer)
 			}
 		}
 
 		companies := api.Group("/companies")
 		companies.Use(auth.Middleware(verifier, permissions))
 		{
-			companies.POST("", companyHandler.Create)
+			companies.POST("", auth.RequireIdentityType(auth.IdentityEmployee), companyHandler.Create)
 		}
 
 		payees := api.Group("/payees")
 		payees.Use(auth.Middleware(verifier, permissions))
 		{
-			payees.GET("", payeeHandler.GetAll)
-			payees.POST("", payeeHandler.Create)
-			payees.PATCH("/:id", payeeHandler.Update)
-			payees.DELETE("/:id", payeeHandler.Delete)
+			payees.GET("", auth.RequireIdentityType(auth.IdentityClient), payeeHandler.GetAll)
+			payees.POST("", auth.RequireIdentityType(auth.IdentityClient), payeeHandler.Create)
+			payees.PATCH("/:id", auth.RequireIdentityType(auth.IdentityClient), payeeHandler.Update)
+			payees.DELETE("/:id", auth.RequireIdentityType(auth.IdentityClient), payeeHandler.Delete)
 		}
 
 		cards := api.Group("/cards")
@@ -150,42 +179,6 @@ func SetupRoutes(
 			cards.PUT("/:cardId/deactivate", auth.RequireIdentityType(auth.IdentityEmployee), cardHandler.DeactivateCard)
 		}
 
-		exchange := api.Group("/exchange")
-		{
-			exchange.GET("/rates", exchangeHandler.GetRates)
-			exchange.GET("/calculate", exchangeHandler.Calculate)
-		}
-
-		payments := api.Group("/payments")
-		payments.Use(auth.Middleware(verifier, permissions))
-		{
-			payments.POST("", paymentHandler.CreatePayment)
-			payments.POST("/:id/verify", paymentHandler.VerifyPayment)
-		}
-
-		transfers := api.Group("/transfers")
-		transfers.Use(auth.Middleware(verifier, permissions))
-		{
-			transfers.POST("", auth.RequireIdentityType(auth.IdentityClient), transferHandler.ExecuteTransfer)
-		}
-
-		clients := api.Group("/clients")
-		clients.Use(auth.Middleware(verifier, permissions))
-		{
-			transfers := clients.Group("/:clientId/transfers")
-			transfers.Use(auth.RequireClientSelf("clientId", true))
-			{
-				transfers.GET("", transferHandler.GetTransferHistory)
-			}
-		}
-
-		clientLoans := api.Group("/client/:client_id/loans")
-		clientLoans.Use(auth.Middleware(verifier, permissions))
-		{
-			clientLoans.GET("", loanHandler.GetLoans)
-			clientLoans.GET("/:loan_id", loanHandler.GetLoanByID)
-			clientLoans.POST("/request", loanHandler.SubmitLoanRequest)
-		}
 		loanRequests := api.Group("/loan-requests")
 		loanRequests.Use(auth.Middleware(verifier, permissions))
 		{

--- a/services/banking-service/internal/service/account_service.go
+++ b/services/banking-service/internal/service/account_service.go
@@ -92,6 +92,7 @@ func (s *AccountService) Create(ctx context.Context, req dto.CreateAccountReques
 		if req.CurrencyCode == "" {
 			return nil, errors.BadRequestErr("currency code is required for foreign accounts")
 		}
+
 		currencyCode = req.CurrencyCode
 	}
 
@@ -103,6 +104,7 @@ func (s *AccountService) Create(ctx context.Context, req dto.CreateAccountReques
 	if err != nil {
 		return nil, errors.InternalErr(err)
 	}
+
 	if exists {
 		return nil, errors.ConflictErr("account with this name already exists")
 	}

--- a/services/banking-service/internal/service/loan_service.go
+++ b/services/banking-service/internal/service/loan_service.go
@@ -150,6 +150,7 @@ func (s *LoanService) GetLoanDetails(ctx context.Context, clientID uint, loanID 
 		Installments:    installments,
 	}, nil
 }
+
 func (s *LoanService) GetLoanRequests(ctx context.Context, query *dto.ListLoanRequestsQuery) ([]dto.LoanRequestResponse, int64, error) {
 	requests, total, err := s.loanRepo.FindAll(ctx, query)
 	if err != nil {
@@ -172,15 +173,17 @@ func (s *LoanService) GetLoanRequests(ctx context.Context, query *dto.ListLoanRe
 
 	return response, total, nil
 }
+
 func (s *LoanService) ApproveLoanRequest(ctx context.Context, id uint) error {
 	request, err := s.loanRepo.FindByID(ctx, id)
 	if err != nil {
 		return errors.InternalErr(err)
 	}
+
 	if request == nil {
 		return errors.NotFoundErr("loan request not found")
 	}
-	//obradjujemo samo zahteve koji nisu obradjeni
+
 	if request.Status != model.LoanRequestPending {
 		return errors.BadRequestErr("loan request is not pending")
 	}
@@ -188,15 +191,17 @@ func (s *LoanService) ApproveLoanRequest(ctx context.Context, id uint) error {
 	request.Status = model.LoanRequestApproved
 	return s.loanRepo.Update(ctx, request)
 }
+
 func (s *LoanService) RejectLoanRequest(ctx context.Context, id uint) error {
 	request, err := s.loanRepo.FindByID(ctx, id)
 	if err != nil {
 		return errors.InternalErr(err)
 	}
+
 	if request == nil {
 		return errors.NotFoundErr("loan request not found")
 	}
-	//obradjujemo samo zahteve koji nisu obradjeni
+
 	if request.Status != model.LoanRequestPending {
 		return errors.BadRequestErr("loan request is not pending")
 	}

--- a/services/banking-service/internal/service/payee_service.go
+++ b/services/banking-service/internal/service/payee_service.go
@@ -19,11 +19,11 @@ func NewPayeeService(repo repository.PayeeRepository) *PayeeService {
 
 func (s *PayeeService) GetAll(ctx context.Context) ([]model.Payee, error) {
 	ac := auth.GetAuthFromContext(ctx)
-
 	payees, err := s.repo.FindAllByClientID(ctx, *ac.ClientID)
 	if err != nil {
 		return nil, errors.InternalErr(err)
 	}
+
 	return payees, nil
 }
 
@@ -45,14 +45,15 @@ func (s *PayeeService) Create(ctx context.Context, req dto.CreatePayeeRequest) (
 
 func (s *PayeeService) Update(ctx context.Context, id uint, req dto.UpdatePayeeRequest) (*model.Payee, error) {
 	ac := auth.GetAuthFromContext(ctx)
-
 	payee, err := s.repo.FindByID(ctx, id)
 	if err != nil {
 		return nil, errors.InternalErr(err)
 	}
+
 	if payee == nil {
 		return nil, errors.NotFoundErr("payee not found")
 	}
+
 	if payee.ClientID != *ac.ClientID {
 		return nil, errors.ForbiddenErr("not your payee")
 	}
@@ -60,6 +61,7 @@ func (s *PayeeService) Update(ctx context.Context, id uint, req dto.UpdatePayeeR
 	if req.Name != "" {
 		payee.Name = req.Name
 	}
+
 	if req.AccountNumber != "" {
 		payee.AccountNumber = req.AccountNumber
 	}
@@ -73,14 +75,15 @@ func (s *PayeeService) Update(ctx context.Context, id uint, req dto.UpdatePayeeR
 
 func (s *PayeeService) Delete(ctx context.Context, id uint) error {
 	ac := auth.GetAuthFromContext(ctx)
-
 	payee, err := s.repo.FindByID(ctx, id)
 	if err != nil {
 		return errors.InternalErr(err)
 	}
+
 	if payee == nil {
 		return errors.NotFoundErr("payee not found")
 	}
+
 	if payee.ClientID != *ac.ClientID {
 		return errors.ForbiddenErr("not your payee")
 	}

--- a/services/user-service/docs/docs.go
+++ b/services/user-service/docs/docs.go
@@ -314,8 +314,88 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clients": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of clients. Supports filtering by email, first name, and last name. Requires ClientView permission.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "clients"
+                ],
+                "summary": "List all clients",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by email",
+                        "name": "email",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by first name",
+                        "name": "first_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by last name",
+                        "name": "last_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clients/register": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Creates a new client account and sends an activation email",
                 "consumes": [
                     "application/json"
@@ -362,6 +442,76 @@ const docTemplate = `{
                     },
                     "503": {
                         "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{id}": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Updates client details by ID. Requires ClientUpdate permission.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "clients"
+                ],
+                "summary": "Update a client",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "client",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdateClientRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
@@ -963,6 +1113,37 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.UpdateClientRequest": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "date_of_birth": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string",
+                    "maxLength": 20
+                },
+                "gender": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "phone_number": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.UpdateEmployeeRequest": {
             "type": "object",
             "properties": {
@@ -1029,13 +1210,17 @@ const docTemplate = `{
                 "employee.view",
                 "employee.create",
                 "employee.update",
-                "employee.delete"
+                "employee.delete",
+                "client.view",
+                "client.update"
             ],
             "x-enum-varnames": [
                 "EmployeeView",
                 "EmployeeCreate",
                 "EmployeeUpdate",
-                "EmployeeDelete"
+                "EmployeeDelete",
+                "ClientView",
+                "ClientUpdate"
             ]
         }
     },

--- a/services/user-service/docs/swagger.json
+++ b/services/user-service/docs/swagger.json
@@ -306,8 +306,88 @@
                 }
             }
         },
+        "/api/clients": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a paginated list of clients. Supports filtering by email, first name, and last name. Requires ClientView permission.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "clients"
+                ],
+                "summary": "List all clients",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by email",
+                        "name": "email",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by first name",
+                        "name": "first_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by last name",
+                        "name": "last_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clients/register": {
             "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Creates a new client account and sends an activation email",
                 "consumes": [
                     "application/json"
@@ -354,6 +434,76 @@
                     },
                     "503": {
                         "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clients/{id}": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Updates client details by ID. Requires ClientUpdate permission.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "clients"
+                ],
+                "summary": "Update a client",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Client ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "client",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdateClientRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/errors.AppError"
                         }
@@ -955,6 +1105,37 @@
                 }
             }
         },
+        "dto.UpdateClientRequest": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "date_of_birth": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string",
+                    "maxLength": 20
+                },
+                "gender": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "phone_number": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.UpdateEmployeeRequest": {
             "type": "object",
             "properties": {
@@ -1021,13 +1202,17 @@
                 "employee.view",
                 "employee.create",
                 "employee.update",
-                "employee.delete"
+                "employee.delete",
+                "client.view",
+                "client.update"
             ],
             "x-enum-varnames": [
                 "EmployeeView",
                 "EmployeeCreate",
                 "EmployeeUpdate",
-                "EmployeeDelete"
+                "EmployeeDelete",
+                "ClientView",
+                "ClientUpdate"
             ]
         }
     },

--- a/services/user-service/docs/swagger.yaml
+++ b/services/user-service/docs/swagger.yaml
@@ -212,6 +212,27 @@ definitions:
     - new_password
     - token
     type: object
+  dto.UpdateClientRequest:
+    properties:
+      address:
+        type: string
+      date_of_birth:
+        type: string
+      email:
+        type: string
+      first_name:
+        maxLength: 20
+        type: string
+      gender:
+        type: string
+      last_name:
+        maxLength: 100
+        type: string
+      phone_number:
+        type: string
+      username:
+        type: string
+    type: object
   dto.UpdateEmployeeRequest:
     properties:
       active:
@@ -258,12 +279,16 @@ definitions:
     - employee.create
     - employee.update
     - employee.delete
+    - client.view
+    - client.update
     type: string
     x-enum-varnames:
     - EmployeeView
     - EmployeeCreate
     - EmployeeUpdate
     - EmployeeDelete
+    - ClientView
+    - ClientUpdate
 info:
   contact: {}
   description: API for managing employees, clients, authentication, and permissions.
@@ -466,6 +491,100 @@ paths:
       summary: Reset password
       tags:
       - auth
+  /api/clients:
+    get:
+      description: Returns a paginated list of clients. Supports filtering by email,
+        first name, and last name. Requires ClientView permission.
+      parameters:
+      - description: Filter by email
+        in: query
+        name: email
+        type: string
+      - description: Filter by first name
+        in: query
+        name: first_name
+        type: string
+      - description: Filter by last name
+        in: query
+        name: last_name
+        type: string
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: List all clients
+      tags:
+      - clients
+  /api/clients/{id}:
+    patch:
+      consumes:
+      - application/json
+      description: Updates client details by ID. Requires ClientUpdate permission.
+      parameters:
+      - description: Client ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Fields to update
+        in: body
+        name: client
+        required: true
+        schema:
+          $ref: '#/definitions/dto.UpdateClientRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
+      summary: Update a client
+      tags:
+      - clients
   /api/clients/register:
     post:
       consumes:
@@ -499,6 +618,8 @@ paths:
           description: Service Unavailable
           schema:
             $ref: '#/definitions/errors.AppError'
+      security:
+      - BearerAuth: []
       summary: Register a new client
       tags:
       - clients

--- a/services/user-service/internal/handler/client_handler.go
+++ b/services/user-service/internal/handler/client_handler.go
@@ -31,6 +31,7 @@ func NewClientHandler(service *service.ClientService) *ClientHandler {
 // @Failure 400 {object} errors.AppError
 // @Failure 409 {object} errors.AppError
 // @Failure 503 {object} errors.AppError
+// @Security BearerAuth
 // @Router /api/clients/register [post]
 func (h *ClientHandler) Register(c *gin.Context) {
 	var req dto.CreateClientRequest
@@ -48,6 +49,22 @@ func (h *ClientHandler) Register(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"message": "Registration successful. Please check your email to activate your account."})
 }
 
+// ListClients godoc
+// @Summary List all clients
+// @Description Returns a paginated list of clients. Supports filtering by email, first name, and last name. Requires ClientView permission.
+// @Tags clients
+// @Produce json
+// @Param email query string false "Filter by email"
+// @Param first_name query string false "Filter by first name"
+// @Param last_name query string false "Filter by last name"
+// @Param page query int false "Page number"
+// @Param page_size query int false "Page size"
+// @Success 200 {object} object
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients [get]
 func (h *ClientHandler) ListClients(c *gin.Context) {
 	var req dto.ListClientsQuery
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -74,6 +91,21 @@ func (h *ClientHandler) ListClients(c *gin.Context) {
 	})
 }
 
+// UpdateClient godoc
+// @Summary Update a client
+// @Description Updates client details by ID. Requires ClientUpdate permission.
+// @Tags clients
+// @Accept json
+// @Produce json
+// @Param id path int true "Client ID"
+// @Param client body dto.UpdateClientRequest true "Fields to update"
+// @Success 200 {object} object
+// @Failure 400 {object} errors.AppError
+// @Failure 401 {object} errors.AppError
+// @Failure 403 {object} errors.AppError
+// @Failure 404 {object} errors.AppError
+// @Security BearerAuth
+// @Router /api/clients/{id} [patch]
 func (h *ClientHandler) UpdateClient(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {


### PR DESCRIPTION
 # Summary
  - Consolidated all client-scoped routes (accounts, payments, loans, transfers) under /api/clients/:clientId
  - Added RequireClientSelf middleware to account and payment routes that were missing authorization checks
  - Fixed Swagger annotations across all handlers to match actual route paths, params, and HTTP methods
  - Standardized route param naming to camelCase (clientId, loanId, accountNumber)

