### PR TITLE
Send email on loan approvement

### DIFF
--- a/services/banking-service/internal/service/loan_service.go
+++ b/services/banking-service/internal/service/loan_service.go
@@ -259,7 +259,7 @@ func (s *LoanService) ApproveLoanRequest(ctx context.Context, id uint) error {
 		}
 	}
 
-	return s.txManager.WithinTransaction(ctx, func(txCtx context.Context) error {
+	if err := s.txManager.WithinTransaction(ctx, func(txCtx context.Context) error {
 		transaction := &model.Transaction{
 			PayerAccountNumber:     bankAccountNumber,
 			RecipientAccountNumber: request.AccountNumber,
@@ -307,7 +307,23 @@ func (s *LoanService) ApproveLoanRequest(ctx context.Context, id uint) error {
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	client, err := s.userClient.GetClientByID(ctx, request.ClientID)
+	if err != nil {
+		return errors.ServiceUnavailableErr(err)
+	}
+	if client == nil {
+		return errors.InternalErr(fmt.Errorf("client not found in user service"))
+	}
+
+	if err := s.mailer.Send(client.Email, "Loan request approved", "Your loan request has been approved."); err != nil {
+		log.Printf("failed to send loan approval notification email to client_id=%d: %v", client.Id, err)
+	}
+
+	return nil
 }
 
 func (s *LoanService) RejectLoanRequest(ctx context.Context, id uint) error {

--- a/services/banking-service/internal/service/loan_service_test.go
+++ b/services/banking-service/internal/service/loan_service_test.go
@@ -527,6 +527,25 @@ func TestApproveLoanRequest(t *testing.T) {
 			id:         1,
 			expectErr:  true,
 		},
+		{
+			name:     "user client error on approval",
+			loanRepo: &fakeLoanRepo{},
+			loanRequestRepo: &fakeLoanRequestRepo{
+				request: &model.LoanRequest{
+					ID:                 1,
+					Status:             model.LoanRequestPending,
+					AccountNumber:      "client-account",
+					Amount:             100000,
+					CalculatedRate:     5.5,
+					MonthlyInstallment: 4409.57,
+					RepaymentPeriod:    24,
+				},
+			},
+			userClient: &fakeUserClient{clientErr: fmt.Errorf("user service unavailable")},
+			mailer:     &fakeMailer{},
+			id:         1,
+			expectErr:  true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Added email notification to client when loan request is approved.
1. Added mailer.Send call in ApproveLoanRequest after successful transaction
2. Added test case for user client error on approval