### PR TITLE
Bugfix: /listings responses are doubled

### DIFF
--- a/common/pkg/auth/auth.go
+++ b/common/pkg/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"net/http/httptest"
 	"strconv"
 	"strings"
 
@@ -154,13 +155,16 @@ func hasPermission(perm permission.Permission, permissions []permission.Permissi
 func AnyOf(middlewares ...gin.HandlerFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		for _, m := range middlewares {
-			clone := *c
-			clone.Writer = c.Writer
-			clone.Request = c.Request
-			clone.Set("skipAbort", true)
-			m(&clone)
-			if !clone.IsAborted() {
-				// one middleware passed, let original context continue
+			probeRecorder := httptest.NewRecorder()
+			probe, _ := gin.CreateTestContext(probeRecorder)
+			probe.Request = c.Request
+
+			for key, value := range c.Keys {
+				probe.Set(key, value)
+			}
+
+			m(probe)
+			if !probe.IsAborted() {
 				c.Next()
 				return
 			}

--- a/common/pkg/auth/auth_test.go
+++ b/common/pkg/auth/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -413,4 +414,57 @@ func TestGetSubjectFromContext_InvalidIdentityType(t *testing.T) {
 
 func uintPtr(v uint) *uint {
 	return &v
+}
+
+func TestAnyOf_AllowsSingleExecution(t *testing.T) {
+	t.Parallel()
+
+	var executions int32
+
+	router := gin.New()
+	router.Use(errors.ErrorHandler())
+	router.GET(
+		"/test",
+		auth.AnyOf(
+			func(c *gin.Context) {
+				c.Error(errors.ForbiddenErr("first denied"))
+				c.Abort()
+			},
+			func(c *gin.Context) {
+				c.Next()
+			},
+		),
+		func(c *gin.Context) {
+			atomic.AddInt32(&executions, 1)
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		},
+	)
+
+	w := doGetPath(router, "/test")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, int32(1), atomic.LoadInt32(&executions))
+}
+
+func TestAnyOf_DeniesWhenNoMiddlewareMatches(t *testing.T) {
+	t.Parallel()
+
+	router := gin.New()
+	router.Use(errors.ErrorHandler())
+	router.GET(
+		"/test",
+		auth.AnyOf(
+			func(c *gin.Context) {
+				c.Error(errors.ForbiddenErr("first denied"))
+				c.Abort()
+			},
+			func(c *gin.Context) {
+				c.Error(errors.ForbiddenErr("second denied"))
+				c.Abort()
+			},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := doGetPath(router, "/test")
+	require.Equal(t, http.StatusForbidden, w.Code)
 }

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -35,7 +35,7 @@ services:
       retries: 10
       start_period: 30s
     volumes:
-      - .:/app:Z
+      - .:/app:z
       - /app/tmp
       - /go/pkg/mod
     working_dir: /app/services/user-service
@@ -61,7 +61,7 @@ services:
     healthcheck:
       test: curl -f http://localhost:${BANKING_SERVICE_PORT}/api/health || exit 1
     volumes:
-      - .:/app:Z
+      - .:/app:z
       - /app/tmp
       - /go/pkg/mod
     working_dir: /app/services/banking-service
@@ -87,7 +87,7 @@ services:
     healthcheck:
       test: curl -f http://localhost:${TRADING_SERVICE_PORT}/api/health || exit 1
     volumes:
-      - .:/app:Z
+      - .:/app:z
       - /app/tmp
       - /go/pkg/mod
     working_dir: /app/services/trading-service


### PR DESCRIPTION
This is a fix for an issue https://github.com/RAF-SI-2025/Banka-4-Backend/issues/239.

The bug was in a function `AnyOf` in `auth.go`, that was checking if any of the given middleware would allow for a handler of a path to trigger. The context wasn't properly copied to another variable, and was triggering the handler two times, instead of once.

That would be the last place I would check, but Copilot quickly found it and also wrote the regression tests.