### PR TITLE
add withdrawing money from investment funds

### DIFF
--- a/services/banking-service/internal/service/transaction_processor.go
+++ b/services/banking-service/internal/service/transaction_processor.go
@@ -68,12 +68,6 @@ func (tp *TransactionProcessor) Process(ctx context.Context, transactionID uint)
 			return errors.BadRequestErr("cannot make payment to the same account")
 		}
 
-		for _, acc := range BankAccounts {
-			if recipient.AccountNumber == acc {
-				return errors.BadRequestErr("recipient account cannot be one of the banks accounts")
-			}
-		}
-
 		if transaction.StartCurrencyCode != transaction.EndCurrencyCode {
 			banksAccountTo, err := tp.accountRepo.FindByAccountNumber(ctx, BankAccounts[transaction.StartCurrencyCode])
 			if err != nil {

--- a/services/banking-service/internal/service/transaction_processor_test.go
+++ b/services/banking-service/internal/service/transaction_processor_test.go
@@ -300,31 +300,6 @@ func TestProcess_SelfPayment(t *testing.T) {
 	require.Contains(t, err.Error(), "cannot make payment to the same account")
 }
 
-func TestProcess_RecipientIsBankAccount(t *testing.T) {
-	bankNum := BankAccounts[model.RSD]
-	payer := tpAccount("PAYER", 10_000, model.RSD)
-	bankAcc := tpAccount(bankNum, 1_000_000, model.RSD)
-
-	txRepo := &fakeTpTransactionRepo{
-		tx: &model.Transaction{
-			TransactionID:          1,
-			PayerAccountNumber:     "PAYER",
-			RecipientAccountNumber: bankNum,
-			StartAmount:            100,
-			StartCurrencyCode:      model.RSD,
-			EndAmount:              100,
-			EndCurrencyCode:        model.RSD,
-			Status:                 model.TransactionProcessing,
-		},
-	}
-	accRepo := newFakeTpAccountRepo(payer, bankAcc)
-	tp := newTpProcessor(accRepo, txRepo)
-
-	err := tp.Process(context.Background(), 1)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "recipient account cannot be one of the banks accounts")
-}
-
 func TestProcess_SameCurrencySuccess(t *testing.T) {
 	payer := tpAccount("PAYER", 1000, model.RSD)
 	recip := tpAccount("RECIP", 500, model.RSD)

--- a/services/trading-service/cmd/main.go
+++ b/services/trading-service/cmd/main.go
@@ -78,6 +78,7 @@ func main() {
 			repository.NewStockRepository,
 			repository.NewOptionRepository,
 			job.NewDailyPriceJob,
+			job.NewFundRedemptionJob,
 			service.NewStockService,
 			repository.NewExchangeRepository,
 			service.NewExchangeService,
@@ -103,6 +104,7 @@ func main() {
 			repository.NewInvestmentFundRepository,
 			repository.NewClientFundPositionRepository,
 			repository.NewClientFundInvestmentRepository,
+			repository.NewClientFundRedemptionRepository,
 			service.NewInvestmentFundService,
 			handler.NewInvestmentFundHandler,
 		),
@@ -135,6 +137,7 @@ func main() {
 				&model.InvestmentFund{},
 				&model.ClientFundPosition{},
 				&model.ClientFundInvestment{},
+				&model.ClientFundRedemption{},
 			)
 		}),
 		fx.Invoke(func(lc fx.Lifecycle, svc *service.StockService) {
@@ -224,6 +227,29 @@ func main() {
 				},
 				OnStop: func(ctx context.Context) error {
 					orderService.Stop()
+					return nil
+				},
+			})
+		}),
+		fx.Invoke(func(lc fx.Lifecycle, fundRedemptionJob *job.FundRedemptionJob) {
+			c := cron.New(cron.WithLocation(time.UTC))
+			_, err := c.AddFunc("@every 5m", func() {
+				ctx := context.Background()
+				if err := fundRedemptionJob.Run(ctx); err != nil {
+					logging.Error("Fund redemption job failed", zap.Error(err))
+				}
+			})
+			if err != nil {
+				log.Fatal("Failed to schedule fund redemption job", zap.Error(err))
+			}
+
+			lc.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					c.Start()
+					return nil
+				},
+				OnStop: func(ctx context.Context) error {
+					c.Stop()
 					return nil
 				},
 			})

--- a/services/trading-service/docs/docs.go
+++ b/services/trading-service/docs/docs.go
@@ -958,6 +958,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/investment-funds/{fundId}/withdraw": {
+            "post": {
+                "description": "Allows a client or supervisor to withdraw money from an investment fund position.\nClients must provide one of their own accounts; supervisors must provide a bank account.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "investment-funds"
+                ],
+                "summary": "Withdraw from a fund",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Fund ID",
+                        "name": "fundId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Withdrawal details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.WithdrawFromFundRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.WithdrawFromFundResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/listings/forex": {
             "get": {
                 "produces": [
@@ -3383,6 +3448,59 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.WithdrawFromFundRequest": {
+            "type": "object",
+            "required": [
+                "account_number",
+                "amount"
+            ],
+            "properties": {
+                "account_number": {
+                    "type": "string"
+                },
+                "amount": {
+                    "type": "number"
+                }
+            }
+        },
+        "dto.WithdrawFromFundResponse": {
+            "type": "object",
+            "properties": {
+                "completed_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "destination_account_number": {
+                    "type": "string"
+                },
+                "destination_currency_code": {
+                    "type": "string"
+                },
+                "fund_id": {
+                    "type": "integer"
+                },
+                "fund_name": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "requested_amount_rsd": {
+                    "type": "number"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.FundRedemptionStatus"
+                },
+                "total_invested_rsd": {
+                    "type": "number"
+                },
+                "withdrawn_amount_rsd": {
+                    "type": "number"
+                }
+            }
+        },
         "errors.AppError": {
             "type": "object",
             "properties": {
@@ -3410,6 +3528,17 @@ const docTemplate = `{
                 "AssetTypeOption",
                 "AssetTypeFuture",
                 "AssetTypeForexPair"
+            ]
+        },
+        "model.FundRedemptionStatus": {
+            "type": "string",
+            "enum": [
+                "COMPLETED",
+                "PENDING_LIQUIDATION"
+            ],
+            "x-enum-varnames": [
+                "FundRedemptionCompleted",
+                "FundRedemptionPendingLiquidation"
             ]
         },
         "model.OrderDirection": {

--- a/services/trading-service/docs/swagger.json
+++ b/services/trading-service/docs/swagger.json
@@ -950,6 +950,71 @@
                 }
             }
         },
+        "/api/investment-funds/{fundId}/withdraw": {
+            "post": {
+                "description": "Allows a client or supervisor to withdraw money from an investment fund position.\nClients must provide one of their own accounts; supervisors must provide a bank account.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "investment-funds"
+                ],
+                "summary": "Withdraw from a fund",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Fund ID",
+                        "name": "fundId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Withdrawal details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.WithdrawFromFundRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.WithdrawFromFundResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/listings/forex": {
             "get": {
                 "produces": [
@@ -3375,6 +3440,59 @@
                 }
             }
         },
+        "dto.WithdrawFromFundRequest": {
+            "type": "object",
+            "required": [
+                "account_number",
+                "amount"
+            ],
+            "properties": {
+                "account_number": {
+                    "type": "string"
+                },
+                "amount": {
+                    "type": "number"
+                }
+            }
+        },
+        "dto.WithdrawFromFundResponse": {
+            "type": "object",
+            "properties": {
+                "completed_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "destination_account_number": {
+                    "type": "string"
+                },
+                "destination_currency_code": {
+                    "type": "string"
+                },
+                "fund_id": {
+                    "type": "integer"
+                },
+                "fund_name": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "requested_amount_rsd": {
+                    "type": "number"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.FundRedemptionStatus"
+                },
+                "total_invested_rsd": {
+                    "type": "number"
+                },
+                "withdrawn_amount_rsd": {
+                    "type": "number"
+                }
+            }
+        },
         "errors.AppError": {
             "type": "object",
             "properties": {
@@ -3402,6 +3520,17 @@
                 "AssetTypeOption",
                 "AssetTypeFuture",
                 "AssetTypeForexPair"
+            ]
+        },
+        "model.FundRedemptionStatus": {
+            "type": "string",
+            "enum": [
+                "COMPLETED",
+                "PENDING_LIQUIDATION"
+            ],
+            "x-enum-varnames": [
+                "FundRedemptionCompleted",
+                "FundRedemptionPendingLiquidation"
             ]
         },
         "model.OrderDirection": {

--- a/services/trading-service/docs/swagger.yaml
+++ b/services/trading-service/docs/swagger.yaml
@@ -793,6 +793,41 @@ definitions:
       userType:
         type: string
     type: object
+  dto.WithdrawFromFundRequest:
+    properties:
+      account_number:
+        type: string
+      amount:
+        type: number
+    required:
+    - account_number
+    - amount
+    type: object
+  dto.WithdrawFromFundResponse:
+    properties:
+      completed_at:
+        type: string
+      created_at:
+        type: string
+      destination_account_number:
+        type: string
+      destination_currency_code:
+        type: string
+      fund_id:
+        type: integer
+      fund_name:
+        type: string
+      message:
+        type: string
+      requested_amount_rsd:
+        type: number
+      status:
+        $ref: '#/definitions/model.FundRedemptionStatus'
+      total_invested_rsd:
+        type: number
+      withdrawn_amount_rsd:
+        type: number
+    type: object
   errors.AppError:
     properties:
       message:
@@ -814,6 +849,14 @@ definitions:
     - AssetTypeOption
     - AssetTypeFuture
     - AssetTypeForexPair
+  model.FundRedemptionStatus:
+    enum:
+    - COMPLETED
+    - PENDING_LIQUIDATION
+    type: string
+    x-enum-varnames:
+    - FundRedemptionCompleted
+    - FundRedemptionPendingLiquidation
   model.OrderDirection:
     enum:
     - BUY
@@ -1487,6 +1530,51 @@ paths:
           schema:
             $ref: '#/definitions/errors.AppError'
       summary: Invest into a fund
+      tags:
+      - investment-funds
+  /api/investment-funds/{fundId}/withdraw:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Allows a client or supervisor to withdraw money from an investment fund position.
+        Clients must provide one of their own accounts; supervisors must provide a bank account.
+      parameters:
+      - description: Fund ID
+        in: path
+        name: fundId
+        required: true
+        type: integer
+      - description: Withdrawal details
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.WithdrawFromFundRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.WithdrawFromFundResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.AppError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.AppError'
+      summary: Withdraw from a fund
       tags:
       - investment-funds
   /api/listings/forex:

--- a/services/trading-service/handler/investment_fund_handler.go
+++ b/services/trading-service/handler/investment_fund_handler.go
@@ -199,7 +199,7 @@ func (h *InvestmentFundHandler) WithdrawFromFund(c *gin.Context) {
 	}
 
 	resp, err := h.service.WithdrawFromFund(c.Request.Context(), uint(fundID), req)
-  if err != nil {
+	if err != nil {
 		_ = c.Error(err)
 		return
 	}

--- a/services/trading-service/handler/investment_fund_handler.go
+++ b/services/trading-service/handler/investment_fund_handler.go
@@ -168,3 +168,41 @@ func (h *InvestmentFundHandler) InvestInFund(c *gin.Context) {
 
 	c.JSON(http.StatusOK, resp)
 }
+
+// WithdrawFromFund godoc
+//
+//	@Summary		Withdraw from a fund
+//	@Description	Allows a client or supervisor to withdraw money from an investment fund position.
+//	@Description	Clients must provide one of their own accounts; supervisors must provide a bank account.
+//	@Tags			investment-funds
+//	@Accept			json
+//	@Produce		json
+//	@Param			fundId	path		int								true	"Fund ID"
+//	@Param			body	body		dto.WithdrawFromFundRequest	true	"Withdrawal details"
+//	@Success		200		{object}	dto.WithdrawFromFundResponse
+//	@Failure		400		{object}	errors.AppError
+//	@Failure		401		{object}	errors.AppError
+//	@Failure		403		{object}	errors.AppError
+//	@Failure		404		{object}	errors.AppError
+//	@Router			/api/investment-funds/{fundId}/withdraw [post]
+func (h *InvestmentFundHandler) WithdrawFromFund(c *gin.Context) {
+	fundID, err := strconv.ParseUint(c.Param("fundId"), 10, 64)
+	if err != nil || fundID == 0 {
+		_ = c.Error(errors.BadRequestErr("invalid fund id"))
+		return
+	}
+
+	var req dto.WithdrawFromFundRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		_ = c.Error(errors.BadRequestErr(err.Error()))
+		return
+	}
+
+	resp, err := h.service.WithdrawFromFund(c.Request.Context(), uint(fundID), req)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}

--- a/services/trading-service/internal/dto/withdraw_from_fund_request.go
+++ b/services/trading-service/internal/dto/withdraw_from_fund_request.go
@@ -1,0 +1,26 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-4-Backend/services/trading-service/internal/model"
+)
+
+type WithdrawFromFundRequest struct {
+	AccountNumber string  `json:"account_number" binding:"required"`
+	Amount        float64 `json:"amount"         binding:"required,gt=0"`
+}
+
+type WithdrawFromFundResponse struct {
+	FundID                   uint                       `json:"fund_id"`
+	FundName                 string                     `json:"fund_name"`
+	DestinationAccountNumber string                     `json:"destination_account_number"`
+	DestinationCurrencyCode  string                     `json:"destination_currency_code"`
+	RequestedAmountRSD       float64                    `json:"requested_amount_rsd"`
+	WithdrawnAmountRSD       float64                    `json:"withdrawn_amount_rsd"`
+	TotalInvestedRSD         float64                    `json:"total_invested_rsd"`
+	Status                   model.FundRedemptionStatus `json:"status"`
+	Message                  string                     `json:"message,omitempty"`
+	CreatedAt                time.Time                  `json:"created_at"`
+	CompletedAt              *time.Time                 `json:"completed_at,omitempty"`
+}

--- a/services/trading-service/internal/integration_test/setup_test.go
+++ b/services/trading-service/internal/integration_test/setup_test.go
@@ -80,6 +80,7 @@ func TestMain(m *testing.M) {
 		&model.InvestmentFund{},
 		&model.ClientFundPosition{},
 		&model.ClientFundInvestment{},
+		&model.ClientFundRedemption{},
 	); err != nil {
 		log.Fatalf("auto migrate test schema: %v", err)
 	}
@@ -282,13 +283,13 @@ func setupTestRouterWithPermissions(t *testing.T, db *gorm.DB, perms []permissio
 	exchangeSvc := service.NewExchangeService(exchangeRepo)
 	listingSvc := service.NewListingService(listingRepo, futuresRepo, forexRepo, optionRepo)
 	fundRepo := repository.NewInvestmentFundRepository(db)
-	positionRepo := repository.NewClientFundPositionRepository(db)
-	investmentRepo := repository.NewClientFundInvestmentRepository(db)
-	fundSvc := service.NewInvestmentFundService(fundRepo, positionRepo, investmentRepo, assetOwnershipRepo, listingRepo, bankingClient, userClient)
-	fundHandler := handler.NewInvestmentFundHandler(fundSvc)
-
 	var taxRecorder service.TaxRecorder = &fakeTaxRecorder{}
 	orderSvc := service.NewOrderService(orderRepo, orderTxRepo, exchangeRepo, listingRepo, assetOwnershipRepo, futuresRepo, optionRepo, fundRepo, userClient, bankingClient, taxRecorder)
+	positionRepo := repository.NewClientFundPositionRepository(db)
+	investmentRepo := repository.NewClientFundInvestmentRepository(db)
+	redemptionRepo := repository.NewClientFundRedemptionRepository(db)
+	fundSvc := service.NewInvestmentFundService(fundRepo, positionRepo, investmentRepo, redemptionRepo, assetOwnershipRepo, listingRepo, bankingClient, userClient, orderSvc)
+	fundHandler := handler.NewInvestmentFundHandler(fundSvc)
 	portfolioSvc := service.NewPortfolioService(assetOwnershipRepo, stockRepo, optionRepo, futuresRepo, forexRepo, bankingClient, userClient)
 
 	taxSvc := service.NewTaxService(taxRepo, bankingClient, cfg)

--- a/services/trading-service/internal/integration_test/withdraw_from_fund_test.go
+++ b/services/trading-service/internal/integration_test/withdraw_from_fund_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/RAF-SI-2025/Banka-4-Backend/services/trading-service/internal/model"
+)
+
+func TestWithdrawFromFund_ClientSuccess(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	router, _ := setupTestRouter(t, db)
+
+	fund := seedInvestmentFund(t, db, fmt.Sprintf("Fund %d", uniqueCounter.Add(1)), 10)
+	position := &model.ClientFundPosition{
+		ClientID:            1,
+		OwnerType:           model.OwnerTypeClient,
+		FundID:              fund.FundID,
+		TotalInvestedAmount: 2000,
+		UpdatedAt:           time.Now(),
+	}
+	require.NoError(t, db.Create(position).Error)
+
+	body := map[string]any{
+		"account_number": "444000100000000001",
+		"amount":         750.0,
+	}
+
+	rec := performRequest(t, router, http.MethodPost, fmt.Sprintf("/api/investment-funds/%d/withdraw", fund.FundID), body, authHeaderForClient(t, 1, 1))
+	requireStatus(t, rec, http.StatusOK)
+
+	resp := decodeResponse[map[string]any](t, rec)
+	require.Equal(t, float64(fund.FundID), resp["fund_id"])
+	require.Equal(t, "COMPLETED", resp["status"])
+	require.Equal(t, 750.0, resp["withdrawn_amount_rsd"])
+	require.Equal(t, 1250.0, resp["total_invested_rsd"])
+
+	var updated model.ClientFundPosition
+	require.NoError(t, db.First(&updated, position.PositionID).Error)
+	require.Equal(t, 1250.0, updated.TotalInvestedAmount)
+}
+
+func TestWithdrawFromFund_SupervisorSuccess(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	router, _ := setupTestRouter(t, db)
+
+	fund := seedInvestmentFund(t, db, fmt.Sprintf("Fund %d", uniqueCounter.Add(1)), 10)
+	position := &model.ClientFundPosition{
+		ClientID:            10,
+		OwnerType:           model.OwnerTypeActuary,
+		FundID:              fund.FundID,
+		TotalInvestedAmount: 3000,
+		UpdatedAt:           time.Now(),
+	}
+	require.NoError(t, db.Create(position).Error)
+
+	body := map[string]any{
+		"account_number": "444000000000000000",
+		"amount":         1000.0,
+	}
+
+	rec := performRequest(t, router, http.MethodPost, fmt.Sprintf("/api/investment-funds/%d/withdraw", fund.FundID), body, authHeaderForSupervisor(t))
+	requireStatus(t, rec, http.StatusOK)
+
+	resp := decodeResponse[map[string]any](t, rec)
+	require.Equal(t, "COMPLETED", resp["status"])
+	require.Equal(t, 2000.0, resp["total_invested_rsd"])
+}
+
+func TestWithdrawFromFund_ExceedsPosition(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	router, _ := setupTestRouter(t, db)
+
+	fund := seedInvestmentFund(t, db, fmt.Sprintf("Fund %d", uniqueCounter.Add(1)), 10)
+	position := &model.ClientFundPosition{
+		ClientID:            1,
+		OwnerType:           model.OwnerTypeClient,
+		FundID:              fund.FundID,
+		TotalInvestedAmount: 500,
+		UpdatedAt:           time.Now(),
+	}
+	require.NoError(t, db.Create(position).Error)
+
+	body := map[string]any{
+		"account_number": "444000100000000001",
+		"amount":         1000.0,
+	}
+
+	rec := performRequest(t, router, http.MethodPost, fmt.Sprintf("/api/investment-funds/%d/withdraw", fund.FundID), body, authHeaderForClient(t, 1, 1))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/services/trading-service/internal/job/fund_redemption_job.go
+++ b/services/trading-service/internal/job/fund_redemption_job.go
@@ -1,0 +1,19 @@
+package job
+
+import (
+	"context"
+
+	"github.com/RAF-SI-2025/Banka-4-Backend/services/trading-service/internal/service"
+)
+
+type FundRedemptionJob struct {
+	fundService *service.InvestmentFundService
+}
+
+func NewFundRedemptionJob(fundService *service.InvestmentFundService) *FundRedemptionJob {
+	return &FundRedemptionJob{fundService: fundService}
+}
+
+func (j *FundRedemptionJob) Run(ctx context.Context) error {
+	return j.fundService.ProcessPendingRedemptions(ctx)
+}

--- a/services/trading-service/internal/model/Investment_fund.go
+++ b/services/trading-service/internal/model/Investment_fund.go
@@ -35,3 +35,24 @@ type ClientFundInvestment struct {
 	CurrencyCode           string  `gorm:"not null;size:10"`
 	CreatedAt              time.Time
 }
+
+type FundRedemptionStatus string
+
+const (
+	FundRedemptionCompleted          FundRedemptionStatus = "COMPLETED"
+	FundRedemptionPendingLiquidation FundRedemptionStatus = "PENDING_LIQUIDATION"
+)
+
+type ClientFundRedemption struct {
+	ClientFundRedemptionID uint      `gorm:"primaryKey;autoIncrement"`
+	ClientID               uint      `gorm:"not null;index"`
+	OwnerType              OwnerType `gorm:"not null;size:10"`
+	FundID                 uint      `gorm:"not null;index"`
+	Fund                   InvestmentFund
+	AccountNumber          string               `gorm:"not null;size:50"`
+	Amount                 float64              `gorm:"not null"`
+	CurrencyCode           string               `gorm:"not null;size:10"`
+	Status                 FundRedemptionStatus `gorm:"not null;size:32;index"`
+	CreatedAt              time.Time
+	CompletedAt            *time.Time
+}

--- a/services/trading-service/internal/repository/client_fund_redemption_repository.go
+++ b/services/trading-service/internal/repository/client_fund_redemption_repository.go
@@ -1,0 +1,14 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/RAF-SI-2025/Banka-4-Backend/services/trading-service/internal/model"
+)
+
+type ClientFundRedemptionRepository interface {
+	Create(ctx context.Context, redemption *model.ClientFundRedemption) error
+	Update(ctx context.Context, redemption *model.ClientFundRedemption) error
+	FindPending(ctx context.Context, limit int) ([]model.ClientFundRedemption, error)
+	SumPendingByClientAndFund(ctx context.Context, clientID uint, ownerType model.OwnerType, fundID uint) (float64, error)
+}

--- a/services/trading-service/internal/repository/client_fund_redemption_repository_impl.go
+++ b/services/trading-service/internal/repository/client_fund_redemption_repository_impl.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"gorm.io/gorm"
+
+	"github.com/RAF-SI-2025/Banka-4-Backend/services/trading-service/internal/model"
+)
+
+type clientFundRedemptionRepository struct {
+	db *gorm.DB
+}
+
+func NewClientFundRedemptionRepository(db *gorm.DB) ClientFundRedemptionRepository {
+	return &clientFundRedemptionRepository{db: db}
+}
+
+func (r *clientFundRedemptionRepository) Create(ctx context.Context, redemption *model.ClientFundRedemption) error {
+	return r.db.WithContext(ctx).Create(redemption).Error
+}
+
+func (r *clientFundRedemptionRepository) Update(ctx context.Context, redemption *model.ClientFundRedemption) error {
+	return r.db.WithContext(ctx).Save(redemption).Error
+}
+
+func (r *clientFundRedemptionRepository) FindPending(ctx context.Context, limit int) ([]model.ClientFundRedemption, error) {
+	var redemptions []model.ClientFundRedemption
+	query := r.db.WithContext(ctx).
+		Preload("Fund").
+		Where("status = ?", model.FundRedemptionPendingLiquidation).
+		Order("created_at ASC")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+
+	err := query.Find(&redemptions).Error
+	return redemptions, err
+}
+
+func (r *clientFundRedemptionRepository) SumPendingByClientAndFund(ctx context.Context, clientID uint, ownerType model.OwnerType, fundID uint) (float64, error) {
+	var total sql.NullFloat64
+	err := r.db.WithContext(ctx).
+		Model(&model.ClientFundRedemption{}).
+		Select("SUM(amount)").
+		Where("client_id = ? AND owner_type = ? AND fund_id = ? AND status = ?", clientID, ownerType, fundID, model.FundRedemptionPendingLiquidation).
+		Scan(&total).Error
+	if err != nil {
+		return 0, err
+	}
+	if !total.Valid {
+		return 0, nil
+	}
+	return total.Float64, nil
+}

--- a/services/trading-service/internal/server/rest.go
+++ b/services/trading-service/internal/server/rest.go
@@ -135,6 +135,13 @@ func SetupRoutes(r *gin.Engine, healthHandler *handler.HealthHandler, taxHandler
 				),
 				fundHandler.InvestInFund,
 			)
+			funds.POST("/:fundId/withdraw",
+				auth.AnyOf(
+					auth.RequireIdentityType(auth.IdentityClient),
+					middleware.RequireSupervisor(userClient),
+				),
+				fundHandler.WithdrawFromFund,
+			)
 		}
 
 		client := api.Group("/client")

--- a/services/trading-service/internal/service/investment_fund_service.go
+++ b/services/trading-service/internal/service/investment_fund_service.go
@@ -3,6 +3,9 @@ package service
 import (
 	"context"
 	"fmt"
+	"log"
+	"math"
+	"sort"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -26,28 +29,36 @@ type InvestmentFundService struct {
 	bankingClient  client.BankingClient
 	userClient     client.UserServiceClient
 	now            func() time.Time
+	redemptionRepo repository.ClientFundRedemptionRepository
+	orderService   *OrderService
 }
 
 func NewInvestmentFundService(
 	fundRepo repository.InvestmentFundRepository,
 	positionRepo repository.ClientFundPositionRepository,
 	investmentRepo repository.ClientFundInvestmentRepository,
+	redemptionRepo repository.ClientFundRedemptionRepository,
 	ownershipRepo repository.AssetOwnershipRepository,
 	listingRepo repository.ListingRepository,
 	bankingClient client.BankingClient,
 	userClient client.UserServiceClient,
+	orderService *OrderService,
 ) *InvestmentFundService {
 	return &InvestmentFundService{
 		fundRepo:       fundRepo,
 		positionRepo:   positionRepo,
 		investmentRepo: investmentRepo,
+		redemptionRepo: redemptionRepo,
 		ownershipRepo:  ownershipRepo,
 		listingRepo:    listingRepo,
 		bankingClient:  bankingClient,
 		userClient:     userClient,
+		orderService:   orderService,
 		now:            time.Now,
 	}
 }
+
+const pendingRedemptionBatchSize = 25
 
 func (s *InvestmentFundService) sumSecuritiesValue(ctx context.Context, fundID uint) (float64, error) {
 	ownerships, err := s.ownershipRepo.FindByUserId(ctx, fundID, model.OwnerTypeFund)
@@ -317,16 +328,7 @@ func (s *InvestmentFundService) InvestInFund(ctx context.Context, fundID uint, r
 	})
 
 	if err != nil {
-		st, ok := status.FromError(err)
-		if ok {
-			switch st.Code() {
-			case codes.NotFound:
-				return nil, commonErrors.NotFoundErr(st.Message())
-			case codes.FailedPrecondition:
-				return nil, commonErrors.BadRequestErr(st.Message())
-			}
-		}
-		return nil, commonErrors.ServiceUnavailableErr(err)
+		return nil, mapFundPaymentError(err)
 	}
 
 	now := s.now()
@@ -374,6 +376,320 @@ func (s *InvestmentFundService) InvestInFund(ctx context.Context, fundID uint, r
 	}, nil
 }
 
+func (s *InvestmentFundService) WithdrawFromFund(ctx context.Context, fundID uint, req dto.WithdrawFromFundRequest) (*dto.WithdrawFromFundResponse, error) {
+	authCtx := auth.GetAuthFromContext(ctx)
+	if authCtx == nil {
+		return nil, commonErrors.UnauthorizedErr("not authenticated")
+	}
+
+	fund, err := s.fundRepo.FindByID(ctx, fundID)
+	if err != nil {
+		return nil, commonErrors.InternalErr(err)
+	}
+	if fund == nil {
+		return nil, commonErrors.NotFoundErr("fund not found")
+	}
+
+	callerID, ownerType, err := resolveCallerIdentity(authCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	destinationAccount, err := s.validateFundAccount(ctx, req.AccountNumber, authCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	position, err := s.positionRepo.FindByClientAndFund(ctx, callerID, ownerType, fundID)
+	if err != nil {
+		return nil, commonErrors.InternalErr(err)
+	}
+	if position == nil || position.TotalInvestedAmount <= 0 {
+		return nil, commonErrors.NotFoundErr("fund position not found")
+	}
+
+	pendingAmount, err := s.redemptionRepo.SumPendingByClientAndFund(ctx, callerID, ownerType, fundID)
+	if err != nil {
+		return nil, commonErrors.InternalErr(err)
+	}
+
+	if req.Amount > position.TotalInvestedAmount-pendingAmount {
+		return nil, commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
+	}
+
+	now := s.now()
+	redemption := &model.ClientFundRedemption{
+		ClientID:      callerID,
+		OwnerType:     ownerType,
+		FundID:        fundID,
+		AccountNumber: req.AccountNumber,
+		Amount:        req.Amount,
+		CurrencyCode:  "RSD",
+		Status:        model.FundRedemptionPendingLiquidation,
+		CreatedAt:     now,
+	}
+
+	liquidAssets, err := s.getLiquidAssets(ctx, fund.AccountNumber)
+	if err != nil {
+		return nil, commonErrors.ServiceUnavailableErr(err)
+	}
+
+	if liquidAssets < req.Amount {
+		ordersCreated, err := s.liquidateFundAssets(ctx, fund, req.Amount-liquidAssets)
+		if err != nil {
+			return nil, err
+		}
+		if ordersCreated == 0 {
+			return nil, commonErrors.BadRequestErr("fund has insufficient liquid assets for this withdrawal")
+		}
+
+		liquidAssets, err = s.getLiquidAssets(ctx, fund.AccountNumber)
+		if err != nil {
+			return nil, commonErrors.ServiceUnavailableErr(err)
+		}
+	}
+
+	if liquidAssets >= req.Amount {
+		return s.completeFundRedemption(ctx, fund, position, redemption, destinationAccount, authCtx.IdentityType == auth.IdentityEmployee)
+	}
+
+	if err := s.redemptionRepo.Create(ctx, redemption); err != nil {
+		return nil, commonErrors.InternalErr(err)
+	}
+
+	return &dto.WithdrawFromFundResponse{
+		FundID:                   fund.FundID,
+		FundName:                 fund.Name,
+		DestinationAccountNumber: req.AccountNumber,
+		DestinationCurrencyCode:  destinationAccount.GetCurrencyCode(),
+		RequestedAmountRSD:       req.Amount,
+		WithdrawnAmountRSD:       0,
+		TotalInvestedRSD:         position.TotalInvestedAmount,
+		Status:                   redemption.Status,
+		Message:                  "Fund liquidation has started; the payout will be completed when liquidity is available",
+		CreatedAt:                redemption.CreatedAt,
+	}, nil
+}
+
+func (s *InvestmentFundService) completeFundRedemption(
+	ctx context.Context,
+	fund *model.InvestmentFund,
+	position *model.ClientFundPosition,
+	redemption *model.ClientFundRedemption,
+	destinationAccount *pb.GetAccountByNumberResponse,
+	commissionExempt bool,
+) (*dto.WithdrawFromFundResponse, error) {
+	_, err := s.bankingClient.CreatePaymentWithoutVerification(ctx, &pb.CreatePaymentRequest{
+		PayerAccountNumber:     fund.AccountNumber,
+		RecipientAccountNumber: redemption.AccountNumber,
+		RecipientName:          fund.Name,
+		Amount:                 redemption.Amount,
+		PaymentCode:            "289",
+		Purpose:                fmt.Sprintf("Withdrawal from fund %s", fund.Name),
+		CommissionExempt:       commissionExempt,
+	})
+	if err != nil {
+		return nil, mapFundPaymentError(err)
+	}
+
+	now := s.now()
+	position.TotalInvestedAmount -= redemption.Amount
+	if position.TotalInvestedAmount < 0 {
+		position.TotalInvestedAmount = 0
+	}
+	position.UpdatedAt = now
+	if err := s.positionRepo.Upsert(ctx, position); err != nil {
+		return nil, commonErrors.InternalErr(err)
+	}
+
+	redemption.Status = model.FundRedemptionCompleted
+	redemption.CompletedAt = &now
+	if redemption.ClientFundRedemptionID == 0 {
+		if err := s.redemptionRepo.Create(ctx, redemption); err != nil {
+			return nil, commonErrors.InternalErr(err)
+		}
+	} else if err := s.redemptionRepo.Update(ctx, redemption); err != nil {
+		return nil, commonErrors.InternalErr(err)
+	}
+
+	return &dto.WithdrawFromFundResponse{
+		FundID:                   fund.FundID,
+		FundName:                 fund.Name,
+		DestinationAccountNumber: redemption.AccountNumber,
+		DestinationCurrencyCode:  destinationAccount.GetCurrencyCode(),
+		RequestedAmountRSD:       redemption.Amount,
+		WithdrawnAmountRSD:       redemption.Amount,
+		TotalInvestedRSD:         position.TotalInvestedAmount,
+		Status:                   redemption.Status,
+		CreatedAt:                redemption.CreatedAt,
+		CompletedAt:              redemption.CompletedAt,
+	}, nil
+}
+
+type fundLiquidationCandidate struct {
+	listing  model.Listing
+	amount   float64
+	priceRSD float64
+}
+
+func (s *InvestmentFundService) liquidateFundAssets(ctx context.Context, fund *model.InvestmentFund, targetRSD float64) (int, error) {
+	ownerships, err := s.ownershipRepo.FindByUserId(ctx, fund.FundID, model.OwnerTypeFund)
+	if err != nil {
+		return 0, commonErrors.InternalErr(err)
+	}
+	if len(ownerships) == 0 {
+		return 0, nil
+	}
+
+	assetIDs := make([]uint, 0, len(ownerships))
+	ownershipByAssetID := make(map[uint]model.AssetOwnership, len(ownerships))
+	for _, ownership := range ownerships {
+		if ownership.Amount <= 0 {
+			continue
+		}
+		assetIDs = append(assetIDs, ownership.AssetID)
+		ownershipByAssetID[ownership.AssetID] = ownership
+	}
+	if len(assetIDs) == 0 {
+		return 0, nil
+	}
+
+	listings, err := s.listingRepo.FindByAssetIDs(ctx, assetIDs)
+	if err != nil {
+		return 0, commonErrors.InternalErr(err)
+	}
+
+	candidates := make([]fundLiquidationCandidate, 0, len(listings))
+	for _, listing := range listings {
+		ownership, ok := ownershipByAssetID[listing.AssetID]
+		if !ok || listing.Price <= 0 {
+			continue
+		}
+
+		currency := "RSD"
+		if listing.Exchange != nil && listing.Exchange.Currency != "" {
+			currency = listing.Exchange.Currency
+		}
+		priceRSD, err := s.bankingClient.ConvertCurrency(ctx, listing.Price, currency, "RSD")
+		if err != nil {
+			return 0, commonErrors.ServiceUnavailableErr(err)
+		}
+		if priceRSD <= 0 {
+			continue
+		}
+
+		candidates = append(candidates, fundLiquidationCandidate{
+			listing:  listing,
+			amount:   ownership.Amount,
+			priceRSD: priceRSD,
+		})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].amount*candidates[i].priceRSD > candidates[j].amount*candidates[j].priceRSD
+	})
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+	if s.orderService == nil {
+		return 0, commonErrors.ServiceUnavailableErr(fmt.Errorf("order service unavailable"))
+	}
+
+	remaining := targetRSD
+	ordersCreated := 0
+	for _, candidate := range candidates {
+		if remaining <= 0 {
+			break
+		}
+
+		availableQuantity := uint(math.Floor(candidate.amount))
+		if availableQuantity == 0 {
+			continue
+		}
+
+		quantity := uint(math.Ceil(remaining / candidate.priceRSD))
+		if quantity == 0 {
+			quantity = 1
+		}
+		if quantity > availableQuantity {
+			quantity = availableQuantity
+		}
+
+		order, err := s.orderService.CreateFundLiquidationOrder(ctx, fund, candidate.listing.ListingID, quantity)
+		if err != nil {
+			return ordersCreated, err
+		}
+
+		ordersCreated++
+		remaining -= float64(quantity) * candidate.priceRSD
+
+		if order.Status == model.OrderStatusApproved {
+			if err := s.orderService.processOrder(ctx, order); err != nil {
+				log.Printf("[fund-redemptions] liquidation order %d processing failed: %v", order.OrderID, err)
+			}
+		}
+	}
+
+	return ordersCreated, nil
+}
+
+func (s *InvestmentFundService) ProcessPendingRedemptions(ctx context.Context) error {
+	if s.redemptionRepo == nil {
+		return nil
+	}
+
+	redemptions, err := s.redemptionRepo.FindPending(ctx, pendingRedemptionBatchSize)
+	if err != nil {
+		return commonErrors.InternalErr(err)
+	}
+
+	for i := range redemptions {
+		if err := s.processPendingRedemption(ctx, &redemptions[i]); err != nil {
+			log.Printf("[fund-redemptions] failed to process redemption %d: %v", redemptions[i].ClientFundRedemptionID, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *InvestmentFundService) processPendingRedemption(ctx context.Context, redemption *model.ClientFundRedemption) error {
+	fund := &redemption.Fund
+	if fund.FundID == 0 {
+		found, err := s.fundRepo.FindByID(ctx, redemption.FundID)
+		if err != nil {
+			return commonErrors.InternalErr(err)
+		}
+		if found == nil {
+			return commonErrors.NotFoundErr("fund not found")
+		}
+		fund = found
+	}
+
+	liquidAssets, err := s.getLiquidAssets(ctx, fund.AccountNumber)
+	if err != nil {
+		return commonErrors.ServiceUnavailableErr(err)
+	}
+	if liquidAssets < redemption.Amount {
+		return nil
+	}
+
+	position, err := s.positionRepo.FindByClientAndFund(ctx, redemption.ClientID, redemption.OwnerType, redemption.FundID)
+	if err != nil {
+		return commonErrors.InternalErr(err)
+	}
+	if position == nil || position.TotalInvestedAmount < redemption.Amount {
+		return commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
+	}
+
+	destinationAccount, err := s.bankingClient.GetAccountByNumber(ctx, redemption.AccountNumber)
+	if err != nil {
+		return commonErrors.ServiceUnavailableErr(err)
+	}
+
+	_, err = s.completeFundRedemption(ctx, fund, position, redemption, destinationAccount, redemption.OwnerType == model.OwnerTypeActuary)
+	return err
+}
+
 func (s *InvestmentFundService) validateFundAccount(ctx context.Context, accountNumber string, authCtx *auth.AuthContext) (*pb.GetAccountByNumberResponse, error) {
 	account, err := s.bankingClient.GetAccountByNumber(ctx, accountNumber)
 	if err != nil {
@@ -383,6 +699,9 @@ func (s *InvestmentFundService) validateFundAccount(ctx context.Context, account
 		}
 		return nil, commonErrors.ServiceUnavailableErr(err)
 	}
+	if account == nil {
+		return nil, commonErrors.NotFoundErr("account not found")
+	}
 
 	switch authCtx.IdentityType {
 	case auth.IdentityClient:
@@ -391,11 +710,24 @@ func (s *InvestmentFundService) validateFundAccount(ctx context.Context, account
 		}
 	case auth.IdentityEmployee:
 		if account.GetAccountType() != "Bank" {
-			return nil, commonErrors.BadRequestErr("supervisors must use a bank account for fund investments")
+			return nil, commonErrors.BadRequestErr("supervisors must use a bank account for fund transactions")
 		}
 	}
 
 	return account, nil
+}
+
+func mapFundPaymentError(err error) error {
+	st, ok := status.FromError(err)
+	if ok {
+		switch st.Code() {
+		case codes.NotFound:
+			return commonErrors.NotFoundErr(st.Message())
+		case codes.FailedPrecondition:
+			return commonErrors.BadRequestErr(st.Message())
+		}
+	}
+	return commonErrors.ServiceUnavailableErr(err)
 }
 
 func resolveCallerIdentity(authCtx *auth.AuthContext) (uint, model.OwnerType, error) {

--- a/services/trading-service/internal/service/investment_fund_test.go
+++ b/services/trading-service/internal/service/investment_fund_test.go
@@ -375,7 +375,7 @@ func newTestFundService(
 	bankingClient *fakeFundBankingClient,
 	userClient *fakeFundUserClient,
 ) *InvestmentFundService {
-  exchange := defaultExchange()
+	exchange := defaultExchange()
 	return NewInvestmentFundService(fundRepo, &fakePositionRepo{}, listingRepo, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, ownershipRepo, &fakeExchangeRepo{exchange: exchange}, bankingClient, userClient, nil)
 }
 
@@ -628,7 +628,7 @@ func TestWithdrawFromFund_ClientSuccess(t *testing.T) {
 		},
 	}
 
-  exchange := defaultExchange()
+	exchange := defaultExchange()
 	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeListingRepo{}, &fakeInvestmentRepo{}, redemptionRepo, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, bankingClient, &fakeFundUserClient{}, nil)
 
 	resp, err := svc.WithdrawFromFund(fundClientCtx(), 1, dto.WithdrawFromFundRequest{
@@ -665,7 +665,7 @@ func TestWithdrawFromFund_SupervisorSuccessCommissionExempt(t *testing.T) {
 			"bank-account": {AccountNumber: "bank-account", AccountType: "Bank", CurrencyCode: "RSD"},
 		},
 	}
-  
+
 	exchange := defaultExchange()
 	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeListingRepo{}, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, bankingClient, &fakeFundUserClient{}, nil)
 
@@ -695,7 +695,7 @@ func TestWithdrawFromFund_ExceedsAvailablePosition(t *testing.T) {
 			"client-account": {AccountNumber: "client-account", ClientId: 99, AccountType: "Current", CurrencyCode: "RSD"},
 		},
 	}
-	
+
 	exchange := defaultExchange()
 	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeListingRepo{}, &fakeInvestmentRepo{}, redemptionRepo, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, bankingClient, &fakeFundUserClient{}, nil)
 

--- a/services/trading-service/internal/service/investment_fund_test.go
+++ b/services/trading-service/internal/service/investment_fund_test.go
@@ -169,9 +169,6 @@ func (f *fakeFundBankingClient) GetAccountByNumber(_ context.Context, accountNum
 	}
 	return nil, nil
 }
-func (f *fakeFundBankingClient) GetAccountByNumber(_ context.Context, _ string) (*pb.GetAccountByNumberResponse, error) {
-	return f.getAccountResult, nil
-}
 func (f *fakeFundBankingClient) HasActiveLoan(_ context.Context, _ uint64) (*pb.HasActiveLoanResponse, error) {
 	return nil, nil
 }
@@ -295,8 +292,7 @@ func (f *fakeUserClient) GetIdentityByUserId(ctx context.Context, userID uint64,
 
 func newTestFundServiceWithListing(fundRepo *fakeFundRepo, listingRepo *fakeListingRepo, bankingClient *fakeFundBankingClient, userClient *fakeUserClient) *InvestmentFundService {
 	exchange := defaultExchange()
-	svc := NewInvestmentFundService(fundRepo, &fakePositionRepo{}, listingRepo, &fakeInvestmentRepo{}, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, bankingClient, userClient)
-	svc.listingRepo = listingRepo // inject listingRepo
+	svc := NewInvestmentFundService(fundRepo, &fakePositionRepo{}, listingRepo, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, bankingClient, userClient, nil)
 	return svc
 }
 
@@ -631,7 +627,9 @@ func TestWithdrawFromFund_ClientSuccess(t *testing.T) {
 			"client-account": {AccountNumber: "client-account", ClientId: 99, AccountType: "Current", CurrencyCode: "RSD"},
 		},
 	}
-	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeInvestmentRepo{}, redemptionRepo, &fakeAssetOwnershipRepo{}, &fakeListingRepo{}, bankingClient, &fakeFundUserClient{}, nil)
+
+  exchange := defaultExchange()
+	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeListingRepo{}, &fakeInvestmentRepo{}, redemptionRepo, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, bankingClient, &fakeFundUserClient{}, nil)
 
 	resp, err := svc.WithdrawFromFund(fundClientCtx(), 1, dto.WithdrawFromFundRequest{
 		AccountNumber: "client-account",
@@ -667,7 +665,9 @@ func TestWithdrawFromFund_SupervisorSuccessCommissionExempt(t *testing.T) {
 			"bank-account": {AccountNumber: "bank-account", AccountType: "Bank", CurrencyCode: "RSD"},
 		},
 	}
-	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, &fakeAssetOwnershipRepo{}, &fakeListingRepo{}, bankingClient, &fakeFundUserClient{}, nil)
+  
+	exchange := defaultExchange()
+	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeListingRepo{}, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, bankingClient, &fakeFundUserClient{}, nil)
 
 	resp, err := svc.WithdrawFromFund(fundSupervisorCtx(), 1, dto.WithdrawFromFundRequest{
 		AccountNumber: "bank-account",
@@ -695,7 +695,9 @@ func TestWithdrawFromFund_ExceedsAvailablePosition(t *testing.T) {
 			"client-account": {AccountNumber: "client-account", ClientId: 99, AccountType: "Current", CurrencyCode: "RSD"},
 		},
 	}
-	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeInvestmentRepo{}, redemptionRepo, &fakeAssetOwnershipRepo{}, &fakeListingRepo{}, bankingClient, &fakeFundUserClient{}, nil)
+	
+	exchange := defaultExchange()
+	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeListingRepo{}, &fakeInvestmentRepo{}, redemptionRepo, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, bankingClient, &fakeFundUserClient{}, nil)
 
 	resp, err := svc.WithdrawFromFund(fundClientCtx(), 1, dto.WithdrawFromFundRequest{
 		AccountNumber: "client-account",
@@ -722,7 +724,9 @@ func TestWithdrawFromFund_InsufficientLiquidityWithoutSecurities(t *testing.T) {
 			"client-account": {AccountNumber: "client-account", ClientId: 99, AccountType: "Current", CurrencyCode: "RSD"},
 		},
 	}
-	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, &fakeAssetOwnershipRepo{}, &fakeListingRepo{}, bankingClient, &fakeFundUserClient{}, nil)
+
+	exchange := defaultExchange()
+	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeListingRepo{}, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, bankingClient, &fakeFundUserClient{}, nil)
 
 	resp, err := svc.WithdrawFromFund(fundClientCtx(), 1, dto.WithdrawFromFundRequest{
 		AccountNumber: "client-account",

--- a/services/trading-service/internal/service/investment_fund_test.go
+++ b/services/trading-service/internal/service/investment_fund_test.go
@@ -69,6 +69,7 @@ type fakePositionRepo struct {
 	findResult *model.ClientFundPosition
 	findErr    error
 	upsertErr  error
+	upserted   *model.ClientFundPosition
 }
 
 func (f *fakePositionRepo) FindByClientAndFund(ctx context.Context, clientID uint, ownerType model.OwnerType, fundID uint) (*model.ClientFundPosition, error) {
@@ -76,6 +77,7 @@ func (f *fakePositionRepo) FindByClientAndFund(ctx context.Context, clientID uin
 }
 
 func (f *fakePositionRepo) Upsert(ctx context.Context, position *model.ClientFundPosition) error {
+	f.upserted = position
 	return f.upsertErr
 }
 
@@ -93,16 +95,60 @@ func (f *fakeInvestmentRepo) FindByClientAndFund(ctx context.Context, clientID u
 	return nil, nil
 }
 
+type fakeRedemptionRepo struct {
+	createErr  error
+	updateErr  error
+	pendingSum float64
+	pendingErr error
+	pending    []model.ClientFundRedemption
+	findErr    error
+	created    *model.ClientFundRedemption
+	updated    *model.ClientFundRedemption
+}
+
+func (f *fakeRedemptionRepo) Create(ctx context.Context, redemption *model.ClientFundRedemption) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	if redemption.ClientFundRedemptionID == 0 {
+		redemption.ClientFundRedemptionID = 1
+	}
+	f.created = redemption
+	return nil
+}
+
+func (f *fakeRedemptionRepo) Update(ctx context.Context, redemption *model.ClientFundRedemption) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	f.updated = redemption
+	return nil
+}
+
+func (f *fakeRedemptionRepo) FindPending(ctx context.Context, limit int) ([]model.ClientFundRedemption, error) {
+	return f.pending, f.findErr
+}
+
+func (f *fakeRedemptionRepo) SumPendingByClientAndFund(ctx context.Context, clientID uint, ownerType model.OwnerType, fundID uint) (float64, error) {
+	return f.pendingSum, f.pendingErr
+}
+
 // ── Fake Fund Banking Client ──────────────────────────────────────
 
 type fakeFundBankingClient struct {
 	createdAccountNumber string
 	createFundAccountErr error
 	getAccountResult     *pb.GetAccountByNumberResponse
+	accountsByNumber     map[string]*pb.GetAccountByNumberResponse
+	paymentErr           error
+	payments             []*pb.CreatePaymentRequest
 	tradeSettlementErr   error
 }
 
-func (f *fakeFundBankingClient) GetAccountByNumber(_ context.Context, _ string) (*pb.GetAccountByNumberResponse, error) {
+func (f *fakeFundBankingClient) GetAccountByNumber(_ context.Context, accountNumber string) (*pb.GetAccountByNumberResponse, error) {
+	if f.accountsByNumber != nil {
+		return f.accountsByNumber[accountNumber], nil
+	}
 	if f.getAccountResult != nil {
 		return f.getAccountResult, nil
 	}
@@ -111,8 +157,12 @@ func (f *fakeFundBankingClient) GetAccountByNumber(_ context.Context, _ string) 
 func (f *fakeFundBankingClient) HasActiveLoan(_ context.Context, _ uint64) (*pb.HasActiveLoanResponse, error) {
 	return nil, nil
 }
-func (f *fakeFundBankingClient) CreatePaymentWithoutVerification(_ context.Context, _ *pb.CreatePaymentRequest) (*pb.CreatePaymentResponse, error) {
-	return nil, nil
+func (f *fakeFundBankingClient) CreatePaymentWithoutVerification(_ context.Context, req *pb.CreatePaymentRequest) (*pb.CreatePaymentResponse, error) {
+	if f.paymentErr != nil {
+		return nil, f.paymentErr
+	}
+	f.payments = append(f.payments, req)
+	return &pb.CreatePaymentResponse{PaymentId: uint64(len(f.payments))}, nil
 }
 func (f *fakeFundBankingClient) GetAccountsByClientID(_ context.Context, _ uint64) (*pb.GetAccountsByClientIDResponse, error) {
 	return nil, nil
@@ -214,7 +264,7 @@ func newTestFundService(
 	bankingClient *fakeFundBankingClient,
 	userClient *fakeFundUserClient,
 ) *InvestmentFundService {
-	return NewInvestmentFundService(fundRepo, &fakePositionRepo{}, &fakeInvestmentRepo{}, ownershipRepo, listingRepo, bankingClient, userClient)
+	return NewInvestmentFundService(fundRepo, &fakePositionRepo{}, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, ownershipRepo, listingRepo, bankingClient, userClient, nil)
 }
 
 // ── CreateFund tests ──────────────────────────────────────────────
@@ -433,4 +483,123 @@ func TestGetActuaryFunds_OwnershipRepoError(t *testing.T) {
 	_, err := svc.GetActuaryFunds(fundSupervisorCtx(), 25)
 
 	require.Error(t, err)
+}
+
+func TestWithdrawFromFund_ClientSuccess(t *testing.T) {
+	fund := &model.InvestmentFund{FundID: 1, Name: "Alpha Growth Fund", AccountNumber: "fund-account"}
+	positionRepo := &fakePositionRepo{findResult: &model.ClientFundPosition{
+		ClientID:            99,
+		OwnerType:           model.OwnerTypeClient,
+		FundID:              1,
+		TotalInvestedAmount: 2000,
+	}}
+	redemptionRepo := &fakeRedemptionRepo{}
+	bankingClient := &fakeFundBankingClient{
+		accountsByNumber: map[string]*pb.GetAccountByNumberResponse{
+			"fund-account":   {AccountNumber: "fund-account", AccountType: "Fund", CurrencyCode: "RSD", AvailableBalance: 2000},
+			"client-account": {AccountNumber: "client-account", ClientId: 99, AccountType: "Current", CurrencyCode: "RSD"},
+		},
+	}
+	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeInvestmentRepo{}, redemptionRepo, &fakeAssetOwnershipRepo{}, &fakeListingRepo{}, bankingClient, &fakeFundUserClient{}, nil)
+
+	resp, err := svc.WithdrawFromFund(fundClientCtx(), 1, dto.WithdrawFromFundRequest{
+		AccountNumber: "client-account",
+		Amount:        1000,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, model.FundRedemptionCompleted, resp.Status)
+	require.Equal(t, 1000.0, resp.WithdrawnAmountRSD)
+	require.Equal(t, 1000.0, resp.TotalInvestedRSD)
+	require.Len(t, bankingClient.payments, 1)
+	require.Equal(t, "fund-account", bankingClient.payments[0].PayerAccountNumber)
+	require.Equal(t, "client-account", bankingClient.payments[0].RecipientAccountNumber)
+	require.False(t, bankingClient.payments[0].CommissionExempt)
+	require.NotNil(t, redemptionRepo.created)
+	require.Equal(t, model.FundRedemptionCompleted, redemptionRepo.created.Status)
+	require.NotNil(t, positionRepo.upserted)
+	require.Equal(t, 1000.0, positionRepo.upserted.TotalInvestedAmount)
+}
+
+func TestWithdrawFromFund_SupervisorSuccessCommissionExempt(t *testing.T) {
+	fund := &model.InvestmentFund{FundID: 1, Name: "Alpha Growth Fund", AccountNumber: "fund-account"}
+	positionRepo := &fakePositionRepo{findResult: &model.ClientFundPosition{
+		ClientID:            25,
+		OwnerType:           model.OwnerTypeActuary,
+		FundID:              1,
+		TotalInvestedAmount: 3000,
+	}}
+	bankingClient := &fakeFundBankingClient{
+		accountsByNumber: map[string]*pb.GetAccountByNumberResponse{
+			"fund-account": {AccountNumber: "fund-account", AccountType: "Fund", CurrencyCode: "RSD", AvailableBalance: 3000},
+			"bank-account": {AccountNumber: "bank-account", AccountType: "Bank", CurrencyCode: "RSD"},
+		},
+	}
+	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, &fakeAssetOwnershipRepo{}, &fakeListingRepo{}, bankingClient, &fakeFundUserClient{}, nil)
+
+	resp, err := svc.WithdrawFromFund(fundSupervisorCtx(), 1, dto.WithdrawFromFundRequest{
+		AccountNumber: "bank-account",
+		Amount:        1500,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, model.FundRedemptionCompleted, resp.Status)
+	require.Len(t, bankingClient.payments, 1)
+	require.True(t, bankingClient.payments[0].CommissionExempt)
+	require.Equal(t, 1500.0, resp.TotalInvestedRSD)
+}
+
+func TestWithdrawFromFund_ExceedsAvailablePosition(t *testing.T) {
+	fund := &model.InvestmentFund{FundID: 1, Name: "Alpha Growth Fund", AccountNumber: "fund-account"}
+	positionRepo := &fakePositionRepo{findResult: &model.ClientFundPosition{
+		ClientID:            99,
+		OwnerType:           model.OwnerTypeClient,
+		FundID:              1,
+		TotalInvestedAmount: 1000,
+	}}
+	redemptionRepo := &fakeRedemptionRepo{pendingSum: 300}
+	bankingClient := &fakeFundBankingClient{
+		accountsByNumber: map[string]*pb.GetAccountByNumberResponse{
+			"client-account": {AccountNumber: "client-account", ClientId: 99, AccountType: "Current", CurrencyCode: "RSD"},
+		},
+	}
+	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeInvestmentRepo{}, redemptionRepo, &fakeAssetOwnershipRepo{}, &fakeListingRepo{}, bankingClient, &fakeFundUserClient{}, nil)
+
+	resp, err := svc.WithdrawFromFund(fundClientCtx(), 1, dto.WithdrawFromFundRequest{
+		AccountNumber: "client-account",
+		Amount:        800,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds available")
+	require.Empty(t, bankingClient.payments)
+}
+
+func TestWithdrawFromFund_InsufficientLiquidityWithoutSecurities(t *testing.T) {
+	fund := &model.InvestmentFund{FundID: 1, Name: "Alpha Growth Fund", AccountNumber: "fund-account"}
+	positionRepo := &fakePositionRepo{findResult: &model.ClientFundPosition{
+		ClientID:            99,
+		OwnerType:           model.OwnerTypeClient,
+		FundID:              1,
+		TotalInvestedAmount: 2000,
+	}}
+	bankingClient := &fakeFundBankingClient{
+		accountsByNumber: map[string]*pb.GetAccountByNumberResponse{
+			"fund-account":   {AccountNumber: "fund-account", AccountType: "Fund", CurrencyCode: "RSD", AvailableBalance: 100},
+			"client-account": {AccountNumber: "client-account", ClientId: 99, AccountType: "Current", CurrencyCode: "RSD"},
+		},
+	}
+	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, &fakeAssetOwnershipRepo{}, &fakeListingRepo{}, bankingClient, &fakeFundUserClient{}, nil)
+
+	resp, err := svc.WithdrawFromFund(fundClientCtx(), 1, dto.WithdrawFromFundRequest{
+		AccountNumber: "client-account",
+		Amount:        1000,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient liquid assets")
+	require.Empty(t, bankingClient.payments)
 }

--- a/services/trading-service/internal/service/order_service.go
+++ b/services/trading-service/internal/service/order_service.go
@@ -252,6 +252,45 @@ func (s *OrderService) CreateFundOrder(ctx context.Context, req dto.CreateFundOr
 	})
 }
 
+func (s *OrderService) CreateFundLiquidationOrder(ctx context.Context, fund *model.InvestmentFund, listingID uint, quantity uint) (*model.Order, error) {
+	if fund == nil {
+		return nil, errors.NotFoundErr("investment fund not found")
+	}
+
+	account, err := s.bankingClient.GetAccountByNumber(ctx, fund.AccountNumber)
+	if err != nil {
+		st, ok := status.FromError(err)
+		if ok && st.Code() == codes.NotFound {
+			return nil, errors.NotFoundErr("account not found")
+		}
+		return nil, errors.ServiceUnavailableErr(err)
+	}
+
+	managerID := fund.ManagerID
+	managerCtx := auth.SetAuthOnContext(ctx, &auth.AuthContext{
+		IdentityID:   managerID,
+		IdentityType: auth.IdentityEmployee,
+		EmployeeID:   &managerID,
+	})
+	managerAuth := auth.GetAuthFromContext(managerCtx)
+
+	return s.placeOrder(managerCtx, managerAuth, placeOrderParams{
+		AccountNumber:    fund.AccountNumber,
+		ListingID:        listingID,
+		OrderType:        model.OrderTypeMarket,
+		Direction:        model.OrderDirectionSell,
+		Quantity:         quantity,
+		AllOrNone:        false,
+		Margin:           false,
+		OrderOwnerUserID: fund.ManagerID,
+		OrderOwnerType:   model.OwnerTypeActuary,
+		AssetOwnerUserID: fund.FundID,
+		AssetOwnerType:   model.OwnerTypeFund,
+		CommissionExempt: true,
+		account:          account,
+	})
+}
+
 func (s *OrderService) placeOrder(ctx context.Context, authCtx *auth.AuthContext, p placeOrderParams) (*model.Order, error) {
 	listing, err := s.listingRepo.FindByID(ctx, p.ListingID, 0)
 	if err != nil {

--- a/services/trading-service/internal/service/order_service_test.go
+++ b/services/trading-service/internal/service/order_service_test.go
@@ -2268,3 +2268,29 @@ func TestCreateFundOrder_Sell_Success(t *testing.T) {
 	require.Equal(t, model.OrderDirectionSell, order.Direction)
 	require.Equal(t, model.OwnerTypeFund, order.AssetOwnerType)
 }
+
+func TestCreateFundLiquidationOrder_UsesFundOrderSemantics(t *testing.T) {
+	const managerID uint = 5
+	fund := defaultFund(managerID)
+	listing := defaultListing()
+	svc := newFundOrderService(
+		&fakeFundRepo{findByIDResult: fund},
+		&fakeAssetOwnershipRepo{
+			ownerships: []model.AssetOwnership{
+				{AssetID: listing.AssetID, UserId: fund.FundID, OwnerType: model.OwnerTypeFund, Amount: 20},
+			},
+		},
+	)
+
+	order, err := svc.CreateFundLiquidationOrder(clientAuthCtx(), fund, listing.ListingID, 5)
+
+	require.NoError(t, err)
+	require.NotNil(t, order)
+	require.Equal(t, managerID, order.OrderOwnerUserID)
+	require.Equal(t, model.OwnerTypeActuary, order.OrderOwnerType)
+	require.Equal(t, fund.FundID, order.AssetOwnerUserID)
+	require.Equal(t, model.OwnerTypeFund, order.AssetOwnerType)
+	require.Equal(t, model.OrderDirectionSell, order.Direction)
+	require.True(t, order.CommissionExempt)
+	require.Equal(t, model.OrderStatusApproved, order.Status)
+}


### PR DESCRIPTION
Added fund redemption model, repository, DTOs, withdrawal handler, route, Swagger docs, and service logic.

Clients can withdraw to their own accounts, supervisors can withdraw to bank accounts. Client withdrawals use normal conversion commission, supervisor withdrawals are commission-exempt.

If fund liquidity is enough, payout completes immediately. If not, the service creates liquidation sell orders for fund-owned assets and stores a pending redemption for retry.

Added background processing for pending redemptions.