### PR TITLE
Bugfix: Actuaries can see the whole banks' portfolio

### DIFF
--- a/services/trading-service/docs/docs.go
+++ b/services/trading-service/docs/docs.go
@@ -5017,12 +5017,12 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "CLIENT",
-                "ACTUARY",
+                "BANK",
                 "FUND"
             ],
             "x-enum-varnames": [
                 "OwnerTypeClient",
-                "OwnerTypeActuary",
+                "OwnerTypeBank",
                 "OwnerTypeFund"
             ]
         }

--- a/services/trading-service/docs/swagger.json
+++ b/services/trading-service/docs/swagger.json
@@ -5009,12 +5009,12 @@
             "type": "string",
             "enum": [
                 "CLIENT",
-                "ACTUARY",
+                "BANK",
                 "FUND"
             ],
             "x-enum-varnames": [
                 "OwnerTypeClient",
-                "OwnerTypeActuary",
+                "OwnerTypeBank",
                 "OwnerTypeFund"
             ]
         }

--- a/services/trading-service/docs/swagger.yaml
+++ b/services/trading-service/docs/swagger.yaml
@@ -1270,12 +1270,12 @@ definitions:
   model.OwnerType:
     enum:
     - CLIENT
-    - ACTUARY
+    - BANK
     - FUND
     type: string
     x-enum-varnames:
     - OwnerTypeClient
-    - OwnerTypeActuary
+    - OwnerTypeBank
     - OwnerTypeFund
 info:
   contact: {}

--- a/services/trading-service/handler/order_handler.go
+++ b/services/trading-service/handler/order_handler.go
@@ -262,7 +262,7 @@ func (h *OrderHandler) GetMyOrders(c *gin.Context) {
 			return
 		}
 		userID = *authCtx.EmployeeID
-		ownerType = model.OwnerTypeActuary
+		ownerType = model.OwnerTypeBank
 	default:
 		c.JSON(http.StatusForbidden, errors.ForbiddenErr("invalid identity type"))
 		return

--- a/services/trading-service/handler/otc_handler.go
+++ b/services/trading-service/handler/otc_handler.go
@@ -104,7 +104,7 @@ func (h *OTCHandler) PublishAssetActuary(c *gin.Context) {
 	}
 	amount := req.Amount
 
-	ownerType := model.OwnerTypeActuary
+	ownerType := model.OwnerTypeBank
 
 	if svcErr := h.service.PublishAsset(c.Request.Context(), uint(ownershipID), uint(actuaryId), ownerType, amount); svcErr != nil {
 		_ = c.Error(svcErr)

--- a/services/trading-service/handler/portfolio_handler.go
+++ b/services/trading-service/handler/portfolio_handler.go
@@ -71,7 +71,7 @@ func (h *PortfolioHandler) GetActuaryPortfolio(c *gin.Context) {
 		return
 	}
 
-	assets, err := h.service.GetActuaryPortfolio(c.Request.Context(), uint(actID))
+	assets, err := h.service.GetWholeBankPortfolio(c.Request.Context(), uint(actID))
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/services/trading-service/handler/portfolio_handler.go
+++ b/services/trading-service/handler/portfolio_handler.go
@@ -232,7 +232,7 @@ func (h *PortfolioHandler) ExerciseOption(c *gin.Context) {
 		return
 	}
 
-	resp, err := h.service.ExerciseOption(c.Request.Context(), uint(actID), model.OwnerTypeActuary, uint(assetID), req.AccountNumber)
+	resp, err := h.service.ExerciseOption(c.Request.Context(), uint(actID), model.OwnerTypeBank, uint(assetID), req.AccountNumber)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/services/trading-service/internal/integration_test/order_integration_test.go
+++ b/services/trading-service/internal/integration_test/order_integration_test.go
@@ -4,10 +4,11 @@ package integration_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/RAF-SI-2025/Banka-4-Backend/services/trading-service/internal/model"
 )
@@ -78,8 +79,8 @@ func TestCreateOrder_LimitOrder(t *testing.T) {
 	ex := seedExchange(t, db, "XNAS")
 	listing := seedListing(t, db, "MSFT", ex.MicCode, model.AssetTypeStock, 400.0)
 	seedStock(t, db, listing.ListingID)
-	// supervisor EmployeeID=10, ownerType=ACTUARY
-	seedAssetOwnership(t, db, 10, model.OwnerTypeActuary, listing.AssetID, 20)
+	// supervisor EmployeeID=10, ownerType=BANK
+	seedAssetOwnership(t, db, 10, model.OwnerTypeBank, listing.AssetID, 20)
 
 	auth := authHeaderForSupervisor(t)
 
@@ -267,7 +268,7 @@ func TestCreateFundOrder_BuyMarket_Success(t *testing.T) {
 	require.Equal(t, fund.FundID, order.AssetOwnerUserID)
 	require.Equal(t, model.OwnerTypeFund, order.AssetOwnerType)
 	require.Equal(t, uint(10), order.OrderOwnerUserID)
-	require.Equal(t, model.OwnerTypeActuary, order.OrderOwnerType)
+	require.Equal(t, model.OwnerTypeBank, order.OrderOwnerType)
 	require.Equal(t, fund.AccountNumber, order.AccountNumber)
 }
 
@@ -434,7 +435,7 @@ func TestGetMyOrders_Employee_Success(t *testing.T) {
 	seedStock(t, db, listing.ListingID)
 
 	// Create orders for employee with identityID=20 (EmployeeID=20)
-	seedOrderForUser(t, db, 20, model.OwnerTypeActuary, listing.ListingID, model.OrderDirectionBuy, model.OrderStatusPending)
+	seedOrderForUser(t, db, 20, model.OwnerTypeBank, listing.ListingID, model.OrderDirectionBuy, model.OrderStatusPending)
 
 	auth := authHeaderForAgent(t) // agent has EmployeeID=20
 	rec := performRequest(t, router, http.MethodGet, "/api/orders/my?page=1&page_size=10", nil, auth)

--- a/services/trading-service/internal/integration_test/otc_integration_test.go
+++ b/services/trading-service/internal/integration_test/otc_integration_test.go
@@ -535,9 +535,24 @@ func TestOTCHandler_PublishAsset_ActuarySuccess(t *testing.T) {
 
 	ex := seedExchange(t, db, uniqueMIC(t))
 	listing := seedListing(t, db, uniqueTicker(t), ex.MicCode, model.AssetTypeStock, 50.0)
-	ownership := seedAssetOwnership(t, db, 20, model.OwnerTypeActuary, listing.AssetID, 15)
+	ownership := seedAssetOwnership(t, db, 20, model.OwnerTypeBank, listing.AssetID, 15)
 
 	path := fmt.Sprintf("/api/actuary/20/assets/%d/publish", ownership.AssetOwnershipID)
+	rec := performRequest(t, router, http.MethodPatch, path, map[string]any{"amount": 3}, authHeaderForAgent(t))
+	requireStatus(t, rec, http.StatusNoContent)
+}
+
+func TestOTCHandler_PublishAsset_DifferentActuarySuccess(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	router, _ := setupTestRouter(t, db)
+
+	ex := seedExchange(t, db, uniqueMIC(t))
+	listing := seedListing(t, db, uniqueTicker(t), ex.MicCode, model.AssetTypeStock, 50.0)
+	ownership := seedAssetOwnership(t, db, 20, model.OwnerTypeBank, listing.AssetID, 15)
+
+	// Different actuary (id = 22) tries to publish asset owned by bank (owner id = 20)
+	path := fmt.Sprintf("/api/actuary/22/assets/%d/publish", ownership.AssetOwnershipID)
 	rec := performRequest(t, router, http.MethodPatch, path, map[string]any{"amount": 3}, authHeaderForAgent(t))
 	requireStatus(t, rec, http.StatusNoContent)
 }
@@ -605,6 +620,20 @@ func TestOTCHandler_PublishAsset_UpdatesExistingPublicAmount(t *testing.T) {
 	var updated model.AssetOwnership
 	require.NoError(t, db.First(&updated, ownership.AssetOwnershipID).Error)
 	require.Equal(t, float64(11), updated.PublicAmount)
+}
+
+func TestOTCHandler_PublishAsset_ClientPublishingBankAsset(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	router, _ := setupTestRouter(t, db)
+
+	ex := seedExchange(t, db, uniqueMIC(t))
+	listing := seedListing(t, db, uniqueTicker(t), ex.MicCode, model.AssetTypeStock, 100.0)
+	ownership := seedAssetOwnership(t, db, 20, model.OwnerTypeBank, listing.AssetID, 15)
+
+	path := fmt.Sprintf("/api/client/99/assets/%d/publish", ownership.AssetOwnershipID)
+	rec := performRequest(t, router, http.MethodPatch, path, map[string]any{"amount": 5}, authHeaderForClient(t, 99, 99))
+	requireStatus(t, rec, http.StatusForbidden)
 }
 
 // --- GetPublicOTCAssets tests (main branch) ---

--- a/services/trading-service/internal/integration_test/portfolio_integration_test.go
+++ b/services/trading-service/internal/integration_test/portfolio_integration_test.go
@@ -182,7 +182,7 @@ func TestExerciseOption_Success(t *testing.T) {
 
 	optionOwnership := &model.AssetOwnership{
 		UserId:         10,
-		OwnerType:      model.OwnerTypeActuary,
+		OwnerType:      model.OwnerTypeBank,
 		AssetID:        optionListing.AssetID,
 		Amount:         100,
 		AvgBuyPriceRSD: 12,
@@ -219,14 +219,14 @@ func TestExerciseOption_Success(t *testing.T) {
 	require.Equal(t, uint(0), response.RemainingContracts)
 
 	var updatedOptionOwnership model.AssetOwnership
-	if err := db.Where("user_id = ? AND owner_type = ? AND asset_id = ?", 10, model.OwnerTypeActuary, optionListing.AssetID).
+	if err := db.Where("user_id = ? AND owner_type = ? AND asset_id = ?", 10, model.OwnerTypeBank, optionListing.AssetID).
 		First(&updatedOptionOwnership).Error; err != nil {
 		t.Fatalf("load updated option ownership: %v", err)
 	}
 	require.Equal(t, 0.0, updatedOptionOwnership.Amount)
 
 	var stockOwnership model.AssetOwnership
-	if err := db.Where("user_id = ? AND owner_type = ? AND asset_id = ?", 10, model.OwnerTypeActuary, stock.AssetID).
+	if err := db.Where("user_id = ? AND owner_type = ? AND asset_id = ?", 10, model.OwnerTypeBank, stock.AssetID).
 		First(&stockOwnership).Error; err != nil {
 		t.Fatalf("load stock ownership: %v", err)
 	}

--- a/services/trading-service/internal/integration_test/withdraw_from_fund_test.go
+++ b/services/trading-service/internal/integration_test/withdraw_from_fund_test.go
@@ -57,7 +57,7 @@ func TestWithdrawFromFund_SupervisorSuccess(t *testing.T) {
 	fund := seedInvestmentFund(t, db, fmt.Sprintf("Fund %d", uniqueCounter.Add(1)), 10)
 	position := &model.ClientFundPosition{
 		ClientID:            10,
-		OwnerType:           model.OwnerTypeActuary,
+		OwnerType:           model.OwnerTypeBank,
 		FundID:              fund.FundID,
 		TotalInvestedAmount: 3000,
 		UpdatedAt:           time.Now(),

--- a/services/trading-service/internal/job/fund_history_job_test.go
+++ b/services/trading-service/internal/job/fund_history_job_test.go
@@ -72,6 +72,9 @@ type dummyOwnershipRepo struct{}
 func (d *dummyOwnershipRepo) FindByUserId(ctx context.Context, userId uint, ownerType model.OwnerType) ([]model.AssetOwnership, error) {
 	return nil, nil
 }
+func (d *dummyOwnershipRepo) FindByOwnerType(ctx context.Context, ownerType model.OwnerType) ([]model.AssetOwnership, error) {
+	return nil, nil
+}
 func (d *dummyOwnershipRepo) FindByID(ctx context.Context, id uint) (*model.AssetOwnership, error) {
 	return nil, nil
 }

--- a/services/trading-service/internal/model/asset_ownership.go
+++ b/services/trading-service/internal/model/asset_ownership.go
@@ -5,9 +5,9 @@ import "time"
 type OwnerType string
 
 const (
-	OwnerTypeClient  OwnerType = "CLIENT"
-	OwnerTypeActuary OwnerType = "ACTUARY"
-	OwnerTypeFund    OwnerType = "FUND"
+	OwnerTypeClient OwnerType = "CLIENT"
+	OwnerTypeBank   OwnerType = "BANK"
+	OwnerTypeFund   OwnerType = "FUND"
 )
 
 type AssetOwnership struct {

--- a/services/trading-service/internal/repository/asset_ownership_repository.go
+++ b/services/trading-service/internal/repository/asset_ownership_repository.go
@@ -8,6 +8,7 @@ import (
 
 type AssetOwnershipRepository interface {
 	FindByUserId(ctx context.Context, userId uint, ownerType model.OwnerType) ([]model.AssetOwnership, error)
+	FindByOwnerType(ctx context.Context, ownerType model.OwnerType) ([]model.AssetOwnership, error)
 	FindByID(ctx context.Context, id uint) (*model.AssetOwnership, error)
 	FindByUserAndAsset(ctx context.Context, userId uint, ownerType model.OwnerType, assetID uint) (*model.AssetOwnership, error)
 	FindByUserAndAssetForUpdate(ctx context.Context, userId uint, ownerType model.OwnerType, assetID uint) (*model.AssetOwnership, error)

--- a/services/trading-service/internal/repository/asset_ownership_repository_impl.go
+++ b/services/trading-service/internal/repository/asset_ownership_repository_impl.go
@@ -30,6 +30,17 @@ func (r *assetOwnershipRepository) FindByUserId(ctx context.Context, userId uint
 	return ownerships, nil
 }
 
+func (r *assetOwnershipRepository) FindByOwnerType(ctx context.Context, ownerType model.OwnerType) ([]model.AssetOwnership, error) {
+	var ownerships []model.AssetOwnership
+	if err := commondb.DBFromContext(ctx, r.db).
+		Where("owner_type = ?", ownerType).
+		Preload("Asset").
+		Find(&ownerships).Error; err != nil {
+		return nil, err
+	}
+	return ownerships, nil
+}
+
 func (r *assetOwnershipRepository) FindByID(ctx context.Context, id uint) (*model.AssetOwnership, error) {
 	var o model.AssetOwnership
 	result := commondb.DBFromContext(ctx, r.db).Preload("Asset").First(&o, id)

--- a/services/trading-service/internal/seed/investment_fund_seed.go
+++ b/services/trading-service/internal/seed/investment_fund_seed.go
@@ -36,7 +36,7 @@ func InvestmentFunds(db *gorm.DB) error {
 		}
 		investment := &model.ClientFundInvestment{
 			ClientID:      funds[i].ManagerID,
-			OwnerType:     model.OwnerTypeActuary,
+			OwnerType:     model.OwnerTypeBank,
 			FundID:        funds[i].FundID,
 			AccountNumber: funds[i].AccountNumber,
 			Amount:        1500000,
@@ -47,7 +47,7 @@ func InvestmentFunds(db *gorm.DB) error {
 			investment,
 			model.ClientFundInvestment{
 				ClientID:  funds[i].ManagerID,
-				OwnerType: model.OwnerTypeActuary,
+				OwnerType: model.OwnerTypeBank,
 				FundID:    funds[i].FundID,
 			},
 		).Error; err != nil {
@@ -56,7 +56,7 @@ func InvestmentFunds(db *gorm.DB) error {
 
 		position := &model.ClientFundPosition{
 			ClientID:            funds[i].ManagerID,
-			OwnerType:           model.OwnerTypeActuary,
+			OwnerType:           model.OwnerTypeBank,
 			FundID:              funds[i].FundID,
 			UnitsOwned:          1500000,
 			TotalInvestedAmount: 1500000,
@@ -67,7 +67,7 @@ func InvestmentFunds(db *gorm.DB) error {
 			position,
 			model.ClientFundPosition{
 				ClientID:  funds[i].ManagerID,
-				OwnerType: model.OwnerTypeActuary,
+				OwnerType: model.OwnerTypeBank,
 				FundID:    funds[i].FundID,
 			},
 		).Error; err != nil {

--- a/services/trading-service/internal/service/investment_fund_service.go
+++ b/services/trading-service/internal/service/investment_fund_service.go
@@ -254,7 +254,7 @@ func (s *InvestmentFundService) GetBankFundPositions(ctx context.Context) ([]dto
 			units := unitsFromPosition(pos)
 			totalUnits += units
 
-			if pos.OwnerType == model.OwnerTypeActuary {
+			if pos.OwnerType == model.OwnerTypeBank {
 				bankUnits += units
 				bankInvested += pos.TotalInvestedAmount
 			}
@@ -813,7 +813,7 @@ func (s *InvestmentFundService) processPendingRedemption(ctx context.Context, re
 		return commonErrors.ServiceUnavailableErr(err)
 	}
 
-	_, err = s.completeFundRedemption(ctx, fund, position, redemption, destinationAccount, redemption.OwnerType == model.OwnerTypeActuary)
+	_, err = s.completeFundRedemption(ctx, fund, position, redemption, destinationAccount, redemption.OwnerType == model.OwnerTypeBank)
 	return err
 }
 
@@ -868,7 +868,7 @@ func resolveCallerIdentity(authCtx *auth.AuthContext) (uint, model.OwnerType, er
 		if authCtx.EmployeeID == nil {
 			return 0, "", commonErrors.UnauthorizedErr("not authenticated")
 		}
-		return *authCtx.EmployeeID, model.OwnerTypeActuary, nil
+		return *authCtx.EmployeeID, model.OwnerTypeBank, nil
 	default:
 		return 0, "", commonErrors.UnauthorizedErr("unknown identity type")
 	}

--- a/services/trading-service/internal/service/investment_fund_test.go
+++ b/services/trading-service/internal/service/investment_fund_test.go
@@ -742,7 +742,7 @@ func TestWithdrawFromFund_SupervisorSuccessCommissionExempt(t *testing.T) {
 	fund := &model.InvestmentFund{FundID: 1, Name: "Alpha Growth Fund", AccountNumber: "fund-account"}
 	positionRepo := &fakePositionRepo{findResult: &model.ClientFundPosition{
 		ClientID:            25,
-		OwnerType:           model.OwnerTypeActuary,
+		OwnerType:           model.OwnerTypeBank,
 		FundID:              1,
 		TotalInvestedAmount: 3000,
 	}}

--- a/services/trading-service/internal/service/order_service.go
+++ b/services/trading-service/internal/service/order_service.go
@@ -184,7 +184,7 @@ func (s *OrderService) CreateOrder(ctx context.Context, req dto.CreateOrderReque
 	ownerType := model.OwnerTypeClient
 	userID := authCtx.ClientID
 	if authCtx.IdentityType == auth.IdentityEmployee {
-		ownerType = model.OwnerTypeActuary
+		ownerType = model.OwnerTypeBank
 		userID = authCtx.EmployeeID
 	}
 
@@ -248,7 +248,7 @@ func (s *OrderService) CreateFundOrder(ctx context.Context, req dto.CreateFundOr
 		AllOrNone:        req.AllOrNone,
 		Margin:           req.Margin,
 		OrderOwnerUserID: *authCtx.EmployeeID,
-		OrderOwnerType:   model.OwnerTypeActuary,
+		OrderOwnerType:   model.OwnerTypeBank,
 		AssetOwnerUserID: req.FundID,
 		AssetOwnerType:   model.OwnerTypeFund,
 		CommissionExempt: true,
@@ -287,7 +287,7 @@ func (s *OrderService) CreateFundLiquidationOrder(ctx context.Context, fund *mod
 		AllOrNone:        false,
 		Margin:           false,
 		OrderOwnerUserID: fund.ManagerID,
-		OrderOwnerType:   model.OwnerTypeActuary,
+		OrderOwnerType:   model.OwnerTypeBank,
 		AssetOwnerUserID: fund.FundID,
 		AssetOwnerType:   model.OwnerTypeFund,
 		CommissionExempt: true,
@@ -430,7 +430,7 @@ func (s *OrderService) ApproveOrder(ctx context.Context, orderID uint) (*model.O
 	}
 	ownerType := model.OwnerTypeClient
 	if authCtx.IdentityType == auth.IdentityEmployee {
-		ownerType = model.OwnerTypeActuary
+		ownerType = model.OwnerTypeBank
 	}
 
 	if order.Direction == model.OrderDirectionSell && order.Listing.Asset != nil {
@@ -695,7 +695,7 @@ func (s *OrderService) processOrder(ctx context.Context, order *model.Order) err
 }
 
 func (s *OrderService) updateActuaryUsedLimit(ctx context.Context, order *model.Order, grossAmount float64, tradeCurrency string) error {
-	if order.OwnerType != model.OwnerTypeActuary || order.Direction != model.OrderDirectionBuy || grossAmount <= 0 {
+	if order.OwnerType != model.OwnerTypeBank || order.Direction != model.OrderDirectionBuy || grossAmount <= 0 {
 		return nil
 	}
 
@@ -739,7 +739,13 @@ func (s *OrderService) updateAssetOwnership(ctx context.Context, order *model.Or
 	assetID := order.Listing.AssetID
 	ownerID, ownerType := assetOwner(order)
 
-	existing, err := s.assetOwnershipRepo.FindByUserId(ctx, ownerID, ownerType)
+	var existing []model.AssetOwnership
+	err := error(nil)
+	if ownerType == model.OwnerTypeBank {
+		existing, err = s.assetOwnershipRepo.FindByOwnerType(ctx, ownerType)
+	} else {
+		existing, err = s.assetOwnershipRepo.FindByUserId(ctx, ownerID, ownerType)
+	}
 	if err != nil {
 		return err
 	}
@@ -832,10 +838,17 @@ func (s *OrderService) resolveOrderStatus(ctx context.Context, authCtx *auth.Aut
 }
 
 func (s *OrderService) validateSellOwnership(ctx context.Context, userId uint, ownerType model.OwnerType, assetID uint, quantity float64) error {
-	ownerships, err := s.assetOwnershipRepo.FindByUserId(ctx, userId, ownerType)
+	var ownerships []model.AssetOwnership
+	err := error(nil)
+	if ownerType == model.OwnerTypeBank {
+		ownerships, err = s.assetOwnershipRepo.FindByOwnerType(ctx, ownerType)
+	} else {
+		ownerships, err = s.assetOwnershipRepo.FindByUserId(ctx, userId, ownerType)
+	}
 	if err != nil {
 		return errors.InternalErr(err)
 	}
+
 	for _, o := range ownerships {
 		if o.AssetID == assetID {
 			if o.Amount < quantity {
@@ -1278,7 +1291,7 @@ func (s *OrderService) recordProfitTax(ctx context.Context, order *model.Order, 
 	}
 
 	var employeeID *uint
-	if order.OrderOwnerType == model.OwnerTypeActuary {
+	if order.OrderOwnerType == model.OwnerTypeBank {
 		employeeID = &order.OrderOwnerUserID
 	}
 	return s.taxService.RecordTax(ctx, order.AccountNumber, employeeID, profitInAccountCurrency, accountCurrency)

--- a/services/trading-service/internal/service/order_service_extra_test.go
+++ b/services/trading-service/internal/service/order_service_extra_test.go
@@ -782,7 +782,7 @@ func TestAssetOwner_WithAssetOwnerUserID_ReturnsAssetOwner(t *testing.T) {
 		AssetOwnerUserID: 42,
 		AssetOwnerType:   model.OwnerTypeFund,
 		OrderOwnerUserID: 10,
-		OrderOwnerType:   model.OwnerTypeActuary,
+		OrderOwnerType:   model.OwnerTypeBank,
 	}
 
 	ownerID, ownerType := assetOwner(order)
@@ -795,12 +795,12 @@ func TestAssetOwner_ZeroAssetOwnerUserID_FallsBackToOrderOwner(t *testing.T) {
 		AssetOwnerUserID: 0,
 		AssetOwnerType:   model.OwnerTypeFund,
 		OrderOwnerUserID: 10,
-		OrderOwnerType:   model.OwnerTypeActuary,
+		OrderOwnerType:   model.OwnerTypeBank,
 	}
 
 	ownerID, ownerType := assetOwner(order)
 	require.Equal(t, uint(10), ownerID)
-	require.Equal(t, model.OwnerTypeActuary, ownerType)
+	require.Equal(t, model.OwnerTypeBank, ownerType)
 }
 
 func TestAssetOwner_ClientOwner_ReturnsClientOwner(t *testing.T) {

--- a/services/trading-service/internal/service/order_service_test.go
+++ b/services/trading-service/internal/service/order_service_test.go
@@ -1803,7 +1803,7 @@ func TestApproveOrder_ActuaryBuy_IncrementsUsedLimit(t *testing.T) {
 		Status:           model.OrderStatusPending,
 		AccountNumber:    "444000100000000110",
 		CommissionExempt: true,
-		OwnerType:        model.OwnerTypeActuary,
+		OwnerType:        model.OwnerTypeBank,
 		PricePerUnit:     &price,
 	}
 	userClient := &fakeUserServiceClient{
@@ -1848,7 +1848,7 @@ func TestApproveOrder_SupervisorBuy_DoesNotIncrementUsedLimit(t *testing.T) {
 		Status:           model.OrderStatusPending,
 		AccountNumber:    "444000100000000110",
 		CommissionExempt: true,
-		OwnerType:        model.OwnerTypeActuary,
+		OwnerType:        model.OwnerTypeBank,
 		PricePerUnit:     &price,
 	}
 	userClient := &fakeUserServiceClient{
@@ -1891,7 +1891,7 @@ func TestApproveOrder_ActuarySell_DoesNotIncrementUsedLimit(t *testing.T) {
 		Status:           model.OrderStatusPending,
 		AccountNumber:    "444000100000000110",
 		CommissionExempt: true,
-		OwnerType:        model.OwnerTypeActuary,
+		OwnerType:        model.OwnerTypeBank,
 		PricePerUnit:     &price,
 	}
 	userClient := &fakeUserServiceClient{
@@ -1908,7 +1908,7 @@ func TestApproveOrder_ActuarySell_DoesNotIncrementUsedLimit(t *testing.T) {
 	)
 	svc.assetOwnershipRepo = &fakeAssetOwnershipRepo{
 		ownerships: []model.AssetOwnership{
-			{AssetID: listing.AssetID, UserId: 5, OwnerType: model.OwnerTypeActuary, Amount: 1, AvgBuyPriceRSD: 200},
+			{AssetID: listing.AssetID, UserId: 5, OwnerType: model.OwnerTypeBank, Amount: 1, AvgBuyPriceRSD: 200},
 		},
 	}
 
@@ -1960,7 +1960,7 @@ func TestProcessOrder_ActuaryBuy_DoesNotIncrementUsedLimit(t *testing.T) {
 		Status:           model.OrderStatusApproved,
 		AccountNumber:    "444000100000000110",
 		CommissionExempt: true,
-		OwnerType:        model.OwnerTypeActuary,
+		OwnerType:        model.OwnerTypeBank,
 	}
 
 	err := svc.processOrder(context.Background(), order)
@@ -2007,7 +2007,7 @@ func TestProcessOrder_SupervisorBuy_DoesNotIncrementUsedLimit(t *testing.T) {
 		Status:           model.OrderStatusApproved,
 		AccountNumber:    "444000100000000110",
 		CommissionExempt: true,
-		OwnerType:        model.OwnerTypeActuary,
+		OwnerType:        model.OwnerTypeBank,
 	}
 
 	err := svc.processOrder(context.Background(), order)
@@ -2038,7 +2038,7 @@ func TestProcessOrder_ActuarySell_DoesNotIncrementUsedLimit(t *testing.T) {
 	)
 	svc.assetOwnershipRepo = &fakeAssetOwnershipRepo{
 		ownerships: []model.AssetOwnership{
-			{AssetID: listing.AssetID, UserId: 5, OwnerType: model.OwnerTypeActuary, Amount: 1, AvgBuyPriceRSD: 200},
+			{AssetID: listing.AssetID, UserId: 5, OwnerType: model.OwnerTypeBank, Amount: 1, AvgBuyPriceRSD: 200},
 		},
 	}
 
@@ -2056,7 +2056,7 @@ func TestProcessOrder_ActuarySell_DoesNotIncrementUsedLimit(t *testing.T) {
 		Status:           model.OrderStatusApproved,
 		AccountNumber:    "444000100000000110",
 		CommissionExempt: true,
-		OwnerType:        model.OwnerTypeActuary,
+		OwnerType:        model.OwnerTypeBank,
 	}
 
 	err := svc.processOrder(context.Background(), order)
@@ -2332,7 +2332,7 @@ func TestRecordProfitTax_ActuarySell_PassesEmployeeID(t *testing.T) {
 		Quantity:         1,
 		FilledQty:        1,
 		ContractSize:     1,
-		OrderOwnerType:   model.OwnerTypeActuary,
+		OrderOwnerType:   model.OwnerTypeBank,
 	}
 
 	err := svc.recordProfitTax(context.Background(), order, 1, 200.0, "RSD")
@@ -2467,7 +2467,7 @@ func TestCreateFundOrder_BuyMarket_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, order)
 	require.Equal(t, managerID, order.OrderOwnerUserID)
-	require.Equal(t, model.OwnerTypeActuary, order.OrderOwnerType)
+	require.Equal(t, model.OwnerTypeBank, order.OrderOwnerType)
 	require.Equal(t, uint(42), order.AssetOwnerUserID)
 	require.Equal(t, model.OwnerTypeFund, order.AssetOwnerType)
 	require.Equal(t, "444000000000000000", order.AccountNumber)
@@ -2627,7 +2627,7 @@ func TestCreateFundLiquidationOrder_UsesFundOrderSemantics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, order)
 	require.Equal(t, managerID, order.OrderOwnerUserID)
-	require.Equal(t, model.OwnerTypeActuary, order.OrderOwnerType)
+	require.Equal(t, model.OwnerTypeBank, order.OrderOwnerType)
 	require.Equal(t, fund.FundID, order.AssetOwnerUserID)
 	require.Equal(t, model.OwnerTypeFund, order.AssetOwnerType)
 	require.Equal(t, model.OrderDirectionSell, order.Direction)
@@ -2690,7 +2690,7 @@ func TestGetMyOrders_Success_Client(t *testing.T) {
 // TestGetMyOrders_Success_Employee tests that an employee (actuary) can retrieve their own orders.
 func TestGetMyOrders_Success_Employee(t *testing.T) {
 	userID := uint(20)
-	ownerType := model.OwnerTypeActuary
+	ownerType := model.OwnerTypeBank
 	expectedOrders := []model.Order{
 		{OrderID: 3, OrderOwnerUserID: userID, OrderOwnerType: ownerType, Status: model.OrderStatusApproved},
 	}

--- a/services/trading-service/internal/service/otc_deal_processing_service.go
+++ b/services/trading-service/internal/service/otc_deal_processing_service.go
@@ -801,7 +801,7 @@ func (s *OtcDealProcessingService) expireContract(ctx context.Context, contractI
 // validateContractForExecution verifies that the contract is still active and
 // eligible for exercise, expiring it on the spot if its settlement time has
 // already passed.
-func (s *OtcDealProcessingService) validateContractForExecution(ctx context.Context, contract *model.OtcOptionContract) error {
+func (s *OtcDealProcessingService) validateContractForExecution(_ context.Context, contract *model.OtcOptionContract) error {
 	if contract.Status == model.OtcOptionContractStatusExercised {
 		return appErrors.ConflictErr("OTC contract has already been exercised")
 	}

--- a/services/trading-service/internal/service/otc_deal_processing_service_test.go
+++ b/services/trading-service/internal/service/otc_deal_processing_service_test.go
@@ -336,6 +336,16 @@ func (r *processingOwnershipRepo) FindByUserId(_ context.Context, userID uint, o
 	return out, nil
 }
 
+func (r *processingOwnershipRepo) FindByOwnerType(_ context.Context, ownerType model.OwnerType) ([]model.AssetOwnership, error) {
+	out := make([]model.AssetOwnership, 0)
+	for _, ownership := range r.ownerships {
+		if ownership.OwnerType == ownerType {
+			out = append(out, *ownership)
+		}
+	}
+	return out, nil
+}
+
 func (r *processingOwnershipRepo) FindByID(_ context.Context, id uint) (*model.AssetOwnership, error) {
 	for _, ownership := range r.ownerships {
 		if ownership.AssetOwnershipID == id || ownership.AssetID == id {

--- a/services/trading-service/internal/service/otc_offer_service_test.go
+++ b/services/trading-service/internal/service/otc_offer_service_test.go
@@ -183,6 +183,16 @@ func (r *fakeOtcAssetOwnershipRepo) FindByUserId(_ context.Context, id uint, ot 
 	return out, nil
 }
 
+func (r *fakeOtcAssetOwnershipRepo) FindByOwnerType(_ context.Context, ot model.OwnerType) ([]model.AssetOwnership, error) {
+	var out []model.AssetOwnership
+	for _, v := range r.ownerships {
+		if v.OwnerType == ot {
+			out = append(out, *v)
+		}
+	}
+	return out, nil
+}
+
 func (r *fakeOtcAssetOwnershipRepo) Upsert(_ context.Context, o *model.AssetOwnership) error {
 	r.ownerships[otcOwnershipKey(o.UserId, o.OwnerType, o.AssetID)] = o
 	return nil

--- a/services/trading-service/internal/service/otc_service.go
+++ b/services/trading-service/internal/service/otc_service.go
@@ -41,7 +41,14 @@ func (s *OTCService) PublishAsset(ctx context.Context, ownershipID, userId uint,
 		return errors.BadRequestErr("only stocks can be published for OTC trading")
 	}
 
-	if ownership.UserId != userId || ownership.OwnerType != ownerType {
+	if ownership.OwnerType != ownerType {
+		return errors.ForbiddenErr("you do not own this asset")
+	}
+	if ownerType == model.OwnerTypeBank {
+		if _, err := s.userClient.GetIdentityByUserId(ctx, uint64(userId), "ACTUARY"); err != nil {
+			return errors.ForbiddenErr("only actuaries can manage this asset")
+		}
+	} else if ownership.UserId != userId {
 		return errors.ForbiddenErr("you do not own this asset")
 	}
 

--- a/services/trading-service/internal/service/otc_service_test.go
+++ b/services/trading-service/internal/service/otc_service_test.go
@@ -43,7 +43,11 @@ func (f *fakeOTCUserClient) GetAllActuaries(_ context.Context, _, _ int32, _, _ 
 	return &pb.GetAllActuariesResponse{}, nil
 }
 
-func (f *fakeOTCUserClient) GetIdentityByUserId(_ context.Context, id uint64, _ string) (*pb.GetIdentityByUserIdResponse, error) {
+func (f *fakeOTCUserClient) GetIdentityByUserId(_ context.Context, id uint64, role string) (*pb.GetIdentityByUserIdResponse, error) {
+	// All users with ID > 100 are actuaries, others are clients
+	if role == "ACTUARY" && id < 100 {
+		return nil, errors.New("not an actuary")
+	}
 	return nil, nil
 }
 
@@ -98,6 +102,13 @@ func TestOTCService_PublishAsset(t *testing.T) {
 			ownershipID: 1, identityID: 10, ownerType: model.OwnerTypeClient, amount: 10,
 		},
 		{
+			name: "happy path - bank asset managed by other actuaries",
+			ownershipRepo: &fakeAssetOwnershipRepo{
+				byID: makeOwnershipForOTC(1, 100, 5, model.OwnerTypeBank, 20, 0),
+			},
+			ownershipID: 1, identityID: 199, ownerType: model.OwnerTypeBank, amount: 5,
+		},
+		{
 			name:          "ownership not found",
 			ownershipRepo: &fakeAssetOwnershipRepo{byID: nil},
 			ownershipID:   99, identityID: 10, ownerType: model.OwnerTypeClient, amount: 5,
@@ -107,7 +118,7 @@ func TestOTCService_PublishAsset(t *testing.T) {
 			},
 		},
 		{
-			name: "identity mismatch",
+			name: "client identity mismatch",
 			ownershipRepo: &fakeAssetOwnershipRepo{
 				byID: makeOwnershipForOTC(1, 10, 5, model.OwnerTypeClient, 20, 0),
 			},
@@ -122,7 +133,7 @@ func TestOTCService_PublishAsset(t *testing.T) {
 			ownershipRepo: &fakeAssetOwnershipRepo{
 				byID: makeOwnershipForOTC(1, 10, 5, model.OwnerTypeClient, 20, 0),
 			},
-			ownershipID: 1, identityID: 10, ownerType: model.OwnerTypeActuary, amount: 5,
+			ownershipID: 1, identityID: 10, ownerType: model.OwnerTypeBank, amount: 5,
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
 				require.Contains(t, err.Error(), "do not own")
@@ -159,6 +170,17 @@ func TestOTCService_PublishAsset(t *testing.T) {
 			},
 			ownershipID: 1, identityID: 10, ownerType: model.OwnerTypeClient, amount: 5,
 			wantErr: true,
+		},
+		{
+			name: "bank asset managed by non-actuary",
+			ownershipRepo: &fakeAssetOwnershipRepo{
+				byID: makeOwnershipForOTC(1, 100, 5, model.OwnerTypeBank, 20, 0),
+			},
+			ownershipID: 1, identityID: 10, ownerType: model.OwnerTypeBank, amount: 5,
+			wantErr: true,
+			checkErr: func(t *testing.T, err error) {
+				require.Contains(t, err.Error(), "only actuaries")
+			},
 		},
 	}
 

--- a/services/trading-service/internal/service/portfolio_service.go
+++ b/services/trading-service/internal/service/portfolio_service.go
@@ -50,11 +50,39 @@ func NewPortfolioService(
 }
 
 func (s *PortfolioService) GetClientPortfolio(ctx context.Context, clientID uint) ([]dto.PortfolioAssetResponse, error) {
-	return s.GetPortfolio(ctx, uint(clientID), model.OwnerTypeClient)
+	ownerships, err := s.ownershipRepo.FindByUserId(ctx, clientID, model.OwnerTypeClient)
+	if err != nil {
+		return nil, pkgerrors.InternalErr(err)
+	}
+
+	return s.GetPortfolio(ctx, ownerships)
 }
 
 func (s *PortfolioService) GetActuaryPortfolio(ctx context.Context, actuaryID uint) ([]dto.PortfolioAssetResponse, error) {
-	return s.GetPortfolio(ctx, uint(actuaryID), model.OwnerTypeActuary)
+	ownerships, err := s.ownershipRepo.FindByUserId(ctx, actuaryID, model.OwnerTypeActuary)
+	if err != nil {
+		return nil, pkgerrors.InternalErr(err)
+	}
+
+	return s.GetPortfolio(ctx, ownerships)
+}
+
+func (s *PortfolioService) GetWholeBankPortfolio(ctx context.Context, actuaryID uint) ([]dto.PortfolioAssetResponse, error) {
+	ownerships, err := s.ownershipRepo.FindByOwnerType(ctx, model.OwnerTypeActuary)
+	if err != nil {
+		return nil, pkgerrors.InternalErr(err)
+	}
+
+	return s.GetPortfolio(ctx, ownerships)
+}
+
+func (s *PortfolioService) GetFundPortfolio(ctx context.Context, fundId uint) ([]dto.PortfolioAssetResponse, error) {
+	ownerships, err := s.ownershipRepo.FindByUserId(ctx, fundId, model.OwnerTypeFund)
+	if err != nil {
+		return nil, pkgerrors.InternalErr(err)
+	}
+
+	return s.GetPortfolio(ctx, ownerships)
 }
 
 func (s *PortfolioService) GetAllActuaryProfits(ctx context.Context, page, pageSize int32, firstName, lastName string) (*dto.PaginatedActuaryProfitResponse, error) {
@@ -105,16 +133,7 @@ func (s *PortfolioService) GetAllActuaryProfits(ctx context.Context, page, pageS
 	}, nil
 }
 
-func (s *PortfolioService) GetFundPortfolio(ctx context.Context, fundId uint) ([]dto.PortfolioAssetResponse, error) {
-	return s.GetPortfolio(ctx, uint(fundId), model.OwnerTypeFund)
-}
-
-func (s *PortfolioService) GetPortfolio(ctx context.Context, userId uint, ownerType model.OwnerType) ([]dto.PortfolioAssetResponse, error) {
-	ownerships, err := s.ownershipRepo.FindByUserId(ctx, userId, ownerType)
-	if err != nil {
-		return nil, pkgerrors.InternalErr(err)
-	}
-
+func (s *PortfolioService) GetPortfolio(ctx context.Context, ownerships []model.AssetOwnership) ([]dto.PortfolioAssetResponse, error) {
 	// Filter to positive positions and collect asset IDs
 	var active []model.AssetOwnership
 	var assetIDs []uint

--- a/services/trading-service/internal/service/portfolio_service.go
+++ b/services/trading-service/internal/service/portfolio_service.go
@@ -59,7 +59,7 @@ func (s *PortfolioService) GetClientPortfolio(ctx context.Context, clientID uint
 }
 
 func (s *PortfolioService) GetActuaryPortfolio(ctx context.Context, actuaryID uint) ([]dto.PortfolioAssetResponse, error) {
-	ownerships, err := s.ownershipRepo.FindByUserId(ctx, actuaryID, model.OwnerTypeActuary)
+	ownerships, err := s.ownershipRepo.FindByUserId(ctx, actuaryID, model.OwnerTypeBank)
 	if err != nil {
 		return nil, pkgerrors.InternalErr(err)
 	}
@@ -68,7 +68,7 @@ func (s *PortfolioService) GetActuaryPortfolio(ctx context.Context, actuaryID ui
 }
 
 func (s *PortfolioService) GetWholeBankPortfolio(ctx context.Context, actuaryID uint) ([]dto.PortfolioAssetResponse, error) {
-	ownerships, err := s.ownershipRepo.FindByOwnerType(ctx, model.OwnerTypeActuary)
+	ownerships, err := s.ownershipRepo.FindByOwnerType(ctx, model.OwnerTypeBank)
 	if err != nil {
 		return nil, pkgerrors.InternalErr(err)
 	}
@@ -254,7 +254,7 @@ func (s *PortfolioService) toRSD(ctx context.Context, amount float64, currency s
 }
 
 func (s *PortfolioService) ExerciseOption(ctx context.Context, userId uint, ownerType model.OwnerType, optionAssetID uint, accountNumber string) (*dto.ExerciseOptionResponse, error) {
-	if ownerType != model.OwnerTypeActuary {
+	if ownerType != model.OwnerTypeBank {
 		return nil, pkgerrors.ForbiddenErr("only actuaries can exercise options")
 	}
 

--- a/services/trading-service/internal/service/portfolio_service_test.go
+++ b/services/trading-service/internal/service/portfolio_service_test.go
@@ -34,6 +34,10 @@ func (r *fakeAssetOwnershipRepo) FindByUserId(_ context.Context, _ uint, _ model
 	return r.ownerships, r.findErr
 }
 
+func (r *fakeAssetOwnershipRepo) FindByOwnerType(_ context.Context, _ model.OwnerType) ([]model.AssetOwnership, error) {
+	return r.ownerships, r.findErr
+}
+
 func (r *fakeAssetOwnershipRepo) Upsert(_ context.Context, ownership *model.AssetOwnership) error {
 	if r.upsertErr != nil {
 		return r.upsertErr
@@ -166,7 +170,7 @@ func TestGetPortfolio_HappyPath_Stock(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	result, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -194,7 +198,7 @@ func TestGetPortfolio_HappyPath_Option(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	result, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -220,7 +224,7 @@ func TestGetPortfolio_HappyPath_Futures(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	result, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -229,6 +233,49 @@ func TestGetPortfolio_HappyPath_Futures(t *testing.T) {
 	require.Equal(t, dto.AssetTypeFutures, a.Type)
 	require.Equal(t, float64(5), a.Amount)
 	require.InDelta(t, (210.0-200.0)*5, a.Profit, 0.001)
+}
+
+func TestGetPortfolio_WholeBank(t *testing.T) {
+	// Should return assets of all actuaries, of any user ID
+	ownership1 := makeOwnership(10, "AAPL", 10, 100.0)
+	ownership1.PublicAmount = 5.0
+	ownership2 := makeOwnership(20, "MSFT", 20, 50.0)
+	ownership2.PublicAmount = 4.0
+	ownership2.UserId = 2
+
+	svc := NewPortfolioService(
+		&fakeAssetOwnershipRepo{ownerships: []model.AssetOwnership{ownership1, ownership2}},
+		&fakeStockRepo{stocks: []model.Stock{
+			{StockID: 1, AssetID: 10, OutstandingShares: 1_000_000, Listing: makeListing(10, 150.0)},
+			{StockID: 2, AssetID: 20, OutstandingShares: 500_000, Listing: makeListing(20, 100.0)},
+		}},
+		&fakeOptionRepo{},
+		&fakeFuturesRepo{},
+		&fakeForexRepo{},
+		&fakeOrderBankingClient{},
+		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
+	)
+
+	result, err := svc.GetWholeBankPortfolio(context.Background(), 1)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	a := result[0]
+	require.Equal(t, uint(10), a.AssetID)
+	require.Equal(t, dto.AssetTypeStock, a.Type)
+	require.Equal(t, "AAPL", a.Ticker)
+	require.Equal(t, float64(10), a.Amount)
+	require.Equal(t, 150.0, a.PricePerUnitRSD)
+	require.InDelta(t, (150.0-100.0)*10, a.Profit, 0.001)
+	require.Equal(t, 5.0, a.PublicAmount)
+	b := result[1]
+	require.Equal(t, uint(20), b.AssetID)
+	require.Equal(t, dto.AssetTypeStock, b.Type)
+	require.Equal(t, "MSFT", b.Ticker)
+	require.Equal(t, float64(20), b.Amount)
+	require.Equal(t, 100.0, b.PricePerUnitRSD)
+	require.InDelta(t, (100.0-50.0)*20, b.Profit, 0.001)
+	require.Equal(t, 4.0, b.PublicAmount)
 }
 
 func TestGetPortfolio_ZeroAmountFiltered(t *testing.T) {
@@ -245,7 +292,7 @@ func TestGetPortfolio_ZeroAmountFiltered(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	result, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Empty(t, result)
 }
@@ -264,7 +311,7 @@ func TestGetPortfolio_NetAmountAfterSell(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	result, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Empty(t, result)
 }
@@ -283,7 +330,7 @@ func TestGetPortfolio_PartialSell(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	result, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	require.Equal(t, float64(6), result[0].Amount)
@@ -300,7 +347,7 @@ func TestGetPortfolio_EmptyOwnerships(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	result, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Empty(t, result)
 }
@@ -316,7 +363,7 @@ func TestGetPortfolio_RepoError(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	_, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	_, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.Error(t, err)
 }
 
@@ -334,7 +381,7 @@ func TestGetPortfolio_NegativeProfit_NoTax(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	result, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	require.InDelta(t, (150.0-200.0)*20, result[0].Profit, 0.001)
@@ -364,7 +411,7 @@ func TestGetPortfolio_MultipleAssets_ProfitAccumulation(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeClient)
+	result, err := svc.GetClientPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 
@@ -387,7 +434,7 @@ func TestGetPortfolio_EmptyPortfolio_ZeroProfit(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	result, err := svc.GetPortfolio(context.Background(), 1, model.OwnerTypeActuary)
+	result, err := svc.GetActuaryPortfolio(context.Background(), 1)
 	require.NoError(t, err)
 	require.Empty(t, result)
 

--- a/services/trading-service/internal/service/portfolio_service_test.go
+++ b/services/trading-service/internal/service/portfolio_service_test.go
@@ -447,7 +447,7 @@ func TestGetPortfolio_EmptyPortfolio_ZeroProfit(t *testing.T) {
 
 func TestExerciseOption_Success(t *testing.T) {
 	optionOwnership := makeOwnership(20, "AAPL:CALL:150.00", 200, 12.0)
-	optionOwnership.OwnerType = model.OwnerTypeActuary
+	optionOwnership.OwnerType = model.OwnerTypeBank
 	optionOwnership.Asset.AssetType = model.AssetTypeOption
 
 	ownershipRepo := &fakeAssetOwnershipRepo{ownerships: []model.AssetOwnership{optionOwnership}}
@@ -492,7 +492,7 @@ func TestExerciseOption_Success(t *testing.T) {
 	)
 	svc.now = func() time.Time { return time.Date(2025, 6, 4, 10, 0, 0, 0, time.UTC) }
 
-	resp, err := svc.ExerciseOption(context.Background(), 1, model.OwnerTypeActuary, 20, "444000100000000001")
+	resp, err := svc.ExerciseOption(context.Background(), 1, model.OwnerTypeBank, 20, "444000100000000001")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, uint(20), resp.OptionAssetID)
@@ -525,7 +525,7 @@ func TestExerciseOption_Success(t *testing.T) {
 
 func TestExerciseOption_ExpiredOption(t *testing.T) {
 	optionOwnership := makeOwnership(20, "AAPL:CALL:150.00", 100, 12.0)
-	optionOwnership.OwnerType = model.OwnerTypeActuary
+	optionOwnership.OwnerType = model.OwnerTypeBank
 	optionOwnership.Asset.AssetType = model.AssetTypeOption
 
 	svc := NewPortfolioService(
@@ -551,14 +551,14 @@ func TestExerciseOption_ExpiredOption(t *testing.T) {
 	)
 	svc.now = func() time.Time { return time.Date(2025, 6, 4, 10, 0, 0, 0, time.UTC) }
 
-	_, err := svc.ExerciseOption(context.Background(), 1, model.OwnerTypeActuary, 20, "444000100000000001")
+	_, err := svc.ExerciseOption(context.Background(), 1, model.OwnerTypeBank, 20, "444000100000000001")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "expired option")
 }
 
 func TestExerciseOption_NotInTheMoney(t *testing.T) {
 	optionOwnership := makeOwnership(20, "AAPL:CALL:150.00", 100, 12.0)
-	optionOwnership.OwnerType = model.OwnerTypeActuary
+	optionOwnership.OwnerType = model.OwnerTypeBank
 	optionOwnership.Asset.AssetType = model.AssetTypeOption
 
 	svc := NewPortfolioService(
@@ -583,14 +583,14 @@ func TestExerciseOption_NotInTheMoney(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	_, err := svc.ExerciseOption(context.Background(), 1, model.OwnerTypeActuary, 20, "444000100000000001")
+	_, err := svc.ExerciseOption(context.Background(), 1, model.OwnerTypeBank, 20, "444000100000000001")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not in the money")
 }
 
 func TestExerciseOption_PutOptionRejected(t *testing.T) {
 	optionOwnership := makeOwnership(20, "AAPL:PUT:150.00", 100, 12.0)
-	optionOwnership.OwnerType = model.OwnerTypeActuary
+	optionOwnership.OwnerType = model.OwnerTypeBank
 	optionOwnership.Asset.AssetType = model.AssetTypeOption
 
 	svc := NewPortfolioService(
@@ -615,7 +615,7 @@ func TestExerciseOption_PutOptionRejected(t *testing.T) {
 		&fakeUserServiceClient{identityResp: &pb.GetIdentityByUserIdResponse{IdentityId: 5}},
 	)
 
-	_, err := svc.ExerciseOption(context.Background(), 1, model.OwnerTypeActuary, 20, "444000100000000001")
+	_, err := svc.ExerciseOption(context.Background(), 1, model.OwnerTypeBank, 20, "444000100000000001")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "only call options can be exercised")
 }
@@ -661,7 +661,7 @@ func TestGetActuaryPortfolio_ResolvesIdentityID(t *testing.T) {
 	const identityID = uint64(55)
 	ownership := makeOwnership(20, "MSFT", 5, 200.0)
 	ownership.UserId = uint(identityID)
-	ownership.OwnerType = model.OwnerTypeActuary
+	ownership.OwnerType = model.OwnerTypeBank
 
 	svc := newPortfolioSvc(
 		&fakeAssetOwnershipRepo{ownerships: []model.AssetOwnership{ownership}},

--- a/services/trading-service/internal/service/watchlist_service.go
+++ b/services/trading-service/internal/service/watchlist_service.go
@@ -51,7 +51,7 @@ func ownerIdentity(ctx context.Context) (uint, model.OwnerType, error) {
 		if authCtx.EmployeeID == nil {
 			return 0, "", commonErrors.UnauthorizedErr("employee identity missing")
 		}
-		return *authCtx.EmployeeID, model.OwnerTypeActuary, nil
+		return *authCtx.EmployeeID, model.OwnerTypeBank, nil
 	default:
 		return 0, "", commonErrors.ForbiddenErr("access denied for this identity type")
 	}


### PR DESCRIPTION
Re: issue https://github.com/RAF-SI-2025/Banka-4-Backend/issues/248.

Now the backend returns assets ~and funds~ of all actuaries ~on the respective requests~.