### PR TITLE
Add UnitsOwned to ClientFundPosition

### DIFF
--- a/services/trading-service/internal/model/Investment_fund.go
+++ b/services/trading-service/internal/model/Investment_fund.go
@@ -20,6 +20,7 @@ type ClientFundPosition struct {
 	Fund                *InvestmentFund `gorm:"constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
 	ClientID            uint            `gorm:"not null;uniqueIndex:idx_fund_client"`
 	OwnerType           OwnerType       `gorm:"not null;size:10;uniqueIndex:idx_fund_client;default:'CLIENT'"`
+	UnitsOwned          float64         `gorm:"not null;default:0"`
 	TotalInvestedAmount float64         `gorm:"not null;default:0"`
 	UpdatedAt           time.Time       `gorm:"not null"`
 }

--- a/services/trading-service/internal/repository/client_fund_repository_impl.go
+++ b/services/trading-service/internal/repository/client_fund_repository_impl.go
@@ -35,7 +35,7 @@ func (r *clientFundPositionRepository) Upsert(ctx context.Context, position *mod
 	return r.db.WithContext(ctx).
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "fund_id"}, {Name: "client_id"}, {Name: "owner_type"}},
-			DoUpdates: clause.AssignmentColumns([]string{"total_invested_amount", "updated_at"}),
+			DoUpdates: clause.AssignmentColumns([]string{"units_owned", "total_invested_amount", "updated_at"}),
 		}).
 		Create(position).Error
 }

--- a/services/trading-service/internal/seed/investment_fund_seed.go
+++ b/services/trading-service/internal/seed/investment_fund_seed.go
@@ -58,6 +58,7 @@ func InvestmentFunds(db *gorm.DB) error {
 			ClientID:            funds[i].ManagerID,
 			OwnerType:           model.OwnerTypeActuary,
 			FundID:              funds[i].FundID,
+			UnitsOwned:          1500000,
 			TotalInvestedAmount: 1500000,
 			UpdatedAt:           now,
 		}

--- a/services/trading-service/internal/service/investment_fund_service.go
+++ b/services/trading-service/internal/service/investment_fund_service.go
@@ -88,10 +88,6 @@ func unitsFromPosition(position model.ClientFundPosition) float64 {
 	return 0
 }
 
-func hasExplicitUnits(position model.ClientFundPosition) bool {
-	return position.UnitsOwned > 0
-}
-
 func calculateFundNAV(fundTotalValue, totalUnits float64) float64 {
 	if totalUnits <= 0 {
 		return defaultFundNAV
@@ -474,14 +470,11 @@ func (s *InvestmentFundService) WithdrawFromFund(ctx context.Context, fundID uin
 		return nil, commonErrors.InternalErr(err)
 	}
 
-	positionValueRSD := position.TotalInvestedAmount
-	if hasExplicitUnits(*position) {
-		nav, err := s.getFundNAV(ctx, fund.FundID, fund.AccountNumber)
-		if err != nil {
-			return nil, err
-		}
-		positionValueRSD = unitsFromPosition(*position) * nav
+	nav, err := s.getFundNAV(ctx, fund.FundID, fund.AccountNumber)
+	if err != nil {
+		return nil, err
 	}
+	positionValueRSD := unitsFromPosition(*position) * nav
 	if req.Amount > positionValueRSD-pendingAmount+floatTolerance {
 		return nil, commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
 	}
@@ -548,19 +541,15 @@ func (s *InvestmentFundService) completeFundRedemption(
 	destinationAccount *pb.GetAccountByNumberResponse,
 	commissionExempt bool,
 ) (*dto.WithdrawFromFundResponse, error) {
-	nav := defaultFundNAV
-	if hasExplicitUnits(*position) {
-		var err error
-		nav, err = s.getFundNAV(ctx, fund.FundID, fund.AccountNumber)
-		if err != nil {
-			return nil, err
-		}
+	nav, err := s.getFundNAV(ctx, fund.FundID, fund.AccountNumber)
+	if err != nil {
+		return nil, err
 	}
 	if redemption.Amount > unitsFromPosition(*position)*nav+floatTolerance {
 		return nil, commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
 	}
 
-	_, err := s.bankingClient.CreatePaymentWithoutVerification(ctx, &pb.CreatePaymentRequest{
+	_, err = s.bankingClient.CreatePaymentWithoutVerification(ctx, &pb.CreatePaymentRequest{
 		PayerAccountNumber:     fund.AccountNumber,
 		RecipientAccountNumber: redemption.AccountNumber,
 		RecipientName:          fund.Name,
@@ -759,14 +748,11 @@ func (s *InvestmentFundService) processPendingRedemption(ctx context.Context, re
 		return commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
 	}
 
-	positionValueRSD := position.TotalInvestedAmount
-	if hasExplicitUnits(*position) {
-		nav, err := s.getFundNAV(ctx, redemption.FundID, fund.AccountNumber)
-		if err != nil {
-			return err
-		}
-		positionValueRSD = unitsFromPosition(*position) * nav
+	nav, err := s.getFundNAV(ctx, redemption.FundID, fund.AccountNumber)
+	if err != nil {
+		return err
 	}
+	positionValueRSD := unitsFromPosition(*position) * nav
 	if positionValueRSD < redemption.Amount-floatTolerance {
 		return commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
 	}
@@ -844,19 +830,6 @@ func (s *InvestmentFundService) getFundSharesValueRSD(ctx context.Context, fundI
 	return securitiesValue, nil
 }
 
-func (s *InvestmentFundService) getFundTotalInvestedRSD(ctx context.Context, fundID uint) (float64, error) {
-	positions, err := s.positionRepo.FindByFund(ctx, fundID)
-	if err != nil {
-		return 0, commonErrors.InternalErr(err)
-	}
-
-	var total float64
-	for _, pos := range positions {
-		total += pos.TotalInvestedAmount
-	}
-	return total, nil
-}
-
 func (s *InvestmentFundService) getFundTotalUnits(ctx context.Context, fundID uint) (float64, error) {
 	positions, err := s.positionRepo.FindByFund(ctx, fundID)
 	if err != nil {
@@ -887,14 +860,6 @@ func (s *InvestmentFundService) getFundNAV(ctx context.Context, fundID uint, acc
 }
 
 func applyRedemptionToPosition(position *model.ClientFundPosition, amountRSD, nav float64) {
-	if !hasExplicitUnits(*position) {
-		position.TotalInvestedAmount -= amountRSD
-		if position.TotalInvestedAmount < floatTolerance {
-			position.TotalInvestedAmount = 0
-		}
-		return
-	}
-
 	currentUnits := unitsFromPosition(*position)
 	if currentUnits <= 0 || nav <= 0 {
 		position.UnitsOwned = 0
@@ -919,6 +884,7 @@ func applyRedemptionToPosition(position *model.ClientFundPosition, amountRSD, na
 		costReductionRatio = 1
 	}
 
+	// Always persist explicit units after first redemption, including legacy rows.
 	position.UnitsOwned = currentUnits - redeemedUnits
 	if position.UnitsOwned < floatTolerance {
 		position.UnitsOwned = 0

--- a/services/trading-service/internal/service/investment_fund_service.go
+++ b/services/trading-service/internal/service/investment_fund_service.go
@@ -74,6 +74,34 @@ func NewInvestmentFundService(
 }
 
 const pendingRedemptionBatchSize = 25
+const defaultFundNAV = 1.0
+const floatTolerance = 1e-9
+
+func unitsFromPosition(position model.ClientFundPosition) float64 {
+	if position.UnitsOwned > 0 {
+		return position.UnitsOwned
+	}
+	// Backward compatibility for legacy rows created before units support.
+	if position.TotalInvestedAmount > 0 {
+		return position.TotalInvestedAmount
+	}
+	return 0
+}
+
+func hasExplicitUnits(position model.ClientFundPosition) bool {
+	return position.UnitsOwned > 0
+}
+
+func calculateFundNAV(fundTotalValue, totalUnits float64) float64 {
+	if totalUnits <= 0 {
+		return defaultFundNAV
+	}
+	nav := fundTotalValue / totalUnits
+	if nav <= 0 || math.IsNaN(nav) || math.IsInf(nav, 0) {
+		return defaultFundNAV
+	}
+	return nav
+}
 
 func (s *InvestmentFundService) sumSecuritiesValue(ctx context.Context, fundID uint) (float64, error) {
 	ownerships, err := s.ownershipRepo.FindByUserId(ctx, fundID, model.OwnerTypeFund)
@@ -170,24 +198,31 @@ func (s *InvestmentFundService) GetBankFundPositions(ctx context.Context) ([]dto
 			return nil, commonErrors.InternalErr(err)
 		}
 
-		var totalInvested float64
+		fundTotalValue := liquidAssets + secVal
+
+		var totalUnits float64
+		var bankUnits float64
 		var bankInvested float64
 		for _, pos := range fund.Positions {
-			totalInvested += pos.TotalInvestedAmount
+			units := unitsFromPosition(pos)
+			totalUnits += units
 
 			if pos.OwnerType == model.OwnerTypeActuary {
+				bankUnits += units
 				bankInvested += pos.TotalInvestedAmount
 			}
 		}
 
+		nav := calculateFundNAV(fundTotalValue, totalUnits)
+
 		var bankPct float64
-		if totalInvested > 0 {
-			bankPct = (bankInvested / totalInvested) * 100
+		if totalUnits > 0 {
+			bankPct = (bankUnits / totalUnits) * 100
 		} else {
 			bankPct = 0
 		}
 
-		bankValue := bankPct / 100.0 * (liquidAssets + secVal)
+		bankValue := bankUnits * nav
 		profit := bankValue - bankInvested
 
 		managerName := ""
@@ -330,6 +365,15 @@ func (s *InvestmentFundService) InvestInFund(ctx context.Context, fundID uint, r
 		)
 	}
 
+	nav, err := s.getFundNAV(ctx, fund.FundID, fund.AccountNumber)
+	if err != nil {
+		return nil, err
+	}
+	unitsBought := amountInRSD / nav
+	if unitsBought <= 0 || math.IsNaN(unitsBought) || math.IsInf(unitsBought, 0) {
+		return nil, commonErrors.BadRequestErr("unable to calculate purchased fund units")
+	}
+
 	commissionExempt := authCtx.IdentityType == auth.IdentityEmployee
 
 	_, err = s.bankingClient.CreatePaymentWithoutVerification(ctx, &pb.CreatePaymentRequest{
@@ -370,10 +414,12 @@ func (s *InvestmentFundService) InvestInFund(ctx context.Context, fundID uint, r
 			ClientID:            callerID,
 			OwnerType:           ownerType,
 			FundID:              fundID,
+			UnitsOwned:          unitsBought,
 			TotalInvestedAmount: amountInRSD,
 			UpdatedAt:           now,
 		}
 	} else {
+		position.UnitsOwned = unitsFromPosition(*position) + unitsBought
 		position.TotalInvestedAmount += amountInRSD
 		position.UpdatedAt = now
 	}
@@ -419,7 +465,7 @@ func (s *InvestmentFundService) WithdrawFromFund(ctx context.Context, fundID uin
 	if err != nil {
 		return nil, commonErrors.InternalErr(err)
 	}
-	if position == nil || position.TotalInvestedAmount <= 0 {
+	if position == nil || unitsFromPosition(*position) <= 0 {
 		return nil, commonErrors.NotFoundErr("fund position not found")
 	}
 
@@ -428,7 +474,15 @@ func (s *InvestmentFundService) WithdrawFromFund(ctx context.Context, fundID uin
 		return nil, commonErrors.InternalErr(err)
 	}
 
-	if req.Amount > position.TotalInvestedAmount-pendingAmount {
+	positionValueRSD := position.TotalInvestedAmount
+	if hasExplicitUnits(*position) {
+		nav, err := s.getFundNAV(ctx, fund.FundID, fund.AccountNumber)
+		if err != nil {
+			return nil, err
+		}
+		positionValueRSD = unitsFromPosition(*position) * nav
+	}
+	if req.Amount > positionValueRSD-pendingAmount+floatTolerance {
 		return nil, commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
 	}
 
@@ -494,6 +548,18 @@ func (s *InvestmentFundService) completeFundRedemption(
 	destinationAccount *pb.GetAccountByNumberResponse,
 	commissionExempt bool,
 ) (*dto.WithdrawFromFundResponse, error) {
+	nav := defaultFundNAV
+	if hasExplicitUnits(*position) {
+		var err error
+		nav, err = s.getFundNAV(ctx, fund.FundID, fund.AccountNumber)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if redemption.Amount > unitsFromPosition(*position)*nav+floatTolerance {
+		return nil, commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
+	}
+
 	_, err := s.bankingClient.CreatePaymentWithoutVerification(ctx, &pb.CreatePaymentRequest{
 		PayerAccountNumber:     fund.AccountNumber,
 		RecipientAccountNumber: redemption.AccountNumber,
@@ -508,10 +574,7 @@ func (s *InvestmentFundService) completeFundRedemption(
 	}
 
 	now := s.now()
-	position.TotalInvestedAmount -= redemption.Amount
-	if position.TotalInvestedAmount < 0 {
-		position.TotalInvestedAmount = 0
-	}
+	applyRedemptionToPosition(position, redemption.Amount, nav)
 	position.UpdatedAt = now
 	if err := s.positionRepo.Upsert(ctx, position); err != nil {
 		return nil, commonErrors.InternalErr(err)
@@ -692,7 +755,19 @@ func (s *InvestmentFundService) processPendingRedemption(ctx context.Context, re
 	if err != nil {
 		return commonErrors.InternalErr(err)
 	}
-	if position == nil || position.TotalInvestedAmount < redemption.Amount {
+	if position == nil {
+		return commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
+	}
+
+	positionValueRSD := position.TotalInvestedAmount
+	if hasExplicitUnits(*position) {
+		nav, err := s.getFundNAV(ctx, redemption.FundID, fund.AccountNumber)
+		if err != nil {
+			return err
+		}
+		positionValueRSD = unitsFromPosition(*position) * nav
+	}
+	if positionValueRSD < redemption.Amount-floatTolerance {
 		return commonErrors.BadRequestErr("withdrawal amount exceeds available fund position")
 	}
 
@@ -782,6 +857,79 @@ func (s *InvestmentFundService) getFundTotalInvestedRSD(ctx context.Context, fun
 	return total, nil
 }
 
+func (s *InvestmentFundService) getFundTotalUnits(ctx context.Context, fundID uint) (float64, error) {
+	positions, err := s.positionRepo.FindByFund(ctx, fundID)
+	if err != nil {
+		return 0, commonErrors.InternalErr(err)
+	}
+
+	var totalUnits float64
+	for _, pos := range positions {
+		totalUnits += unitsFromPosition(pos)
+	}
+	return totalUnits, nil
+}
+
+func (s *InvestmentFundService) getFundNAV(ctx context.Context, fundID uint, accountNumber string) (float64, error) {
+	liquidAssets, err := s.getLiquidAssets(ctx, accountNumber)
+	if err != nil {
+		return 0, commonErrors.InternalErr(err)
+	}
+	sharesValue, err := s.getFundSharesValueRSD(ctx, fundID)
+	if err != nil {
+		return 0, commonErrors.InternalErr(err)
+	}
+	totalUnits, err := s.getFundTotalUnits(ctx, fundID)
+	if err != nil {
+		return 0, err
+	}
+	return calculateFundNAV(liquidAssets+sharesValue, totalUnits), nil
+}
+
+func applyRedemptionToPosition(position *model.ClientFundPosition, amountRSD, nav float64) {
+	if !hasExplicitUnits(*position) {
+		position.TotalInvestedAmount -= amountRSD
+		if position.TotalInvestedAmount < floatTolerance {
+			position.TotalInvestedAmount = 0
+		}
+		return
+	}
+
+	currentUnits := unitsFromPosition(*position)
+	if currentUnits <= 0 || nav <= 0 {
+		position.UnitsOwned = 0
+		position.TotalInvestedAmount = 0
+		return
+	}
+
+	currentValue := currentUnits * nav
+	if currentValue <= 0 {
+		position.UnitsOwned = 0
+		position.TotalInvestedAmount = 0
+		return
+	}
+
+	redeemedUnits := amountRSD / nav
+	if redeemedUnits > currentUnits {
+		redeemedUnits = currentUnits
+	}
+
+	costReductionRatio := amountRSD / currentValue
+	if costReductionRatio > 1 {
+		costReductionRatio = 1
+	}
+
+	position.UnitsOwned = currentUnits - redeemedUnits
+	if position.UnitsOwned < floatTolerance {
+		position.UnitsOwned = 0
+	}
+
+	position.TotalInvestedAmount -= position.TotalInvestedAmount * costReductionRatio
+	if position.TotalInvestedAmount < floatTolerance {
+		position.TotalInvestedAmount = 0
+	}
+}
+
 func (s *InvestmentFundService) GetClientFundPositions(ctx context.Context, clientID uint) ([]dto.FundPositionSummaryResponse, error) {
 	positions, err := s.positionRepo.FindByClient(ctx, clientID, model.OwnerTypeClient)
 	if err != nil {
@@ -808,15 +956,15 @@ func (s *InvestmentFundService) GetClientFundPositions(ctx context.Context, clie
 		}
 
 		fundTotalValue := sharesValue + liquidAssets
-		fundTotalInvested, err := s.getFundTotalInvestedRSD(ctx, pos.FundID)
+		fundTotalUnits, err := s.getFundTotalUnits(ctx, pos.FundID)
 		if err != nil {
 			return nil, err
 		}
 
-		if fundTotalInvested == 0 {
+		if fundTotalUnits == 0 {
 			result[i].ClientsSharePercent = 0
 		} else {
-			result[i].ClientsSharePercent = (pos.TotalInvestedAmount / fundTotalInvested) * 100
+			result[i].ClientsSharePercent = (unitsFromPosition(pos) / fundTotalUnits) * 100
 		}
 		result[i].ClientsShareValueRSD = (result[i].ClientsSharePercent * fundTotalValue) / 100
 		result[i].TotalProfit = result[i].ClientsShareValueRSD - pos.TotalInvestedAmount

--- a/services/trading-service/internal/service/investment_fund_test.go
+++ b/services/trading-service/internal/service/investment_fund_test.go
@@ -813,6 +813,45 @@ func TestWithdrawFromFund_InsufficientLiquidityWithoutSecurities(t *testing.T) {
 	require.Empty(t, bankingClient.payments)
 }
 
+func TestWithdrawFromFund_LegacyPositionUsesNAVForAvailableValue(t *testing.T) {
+	fund := &model.InvestmentFund{FundID: 1, Name: "Alpha Growth Fund", AccountNumber: "fund-account"}
+	positionRepo := &fakePositionRepo{
+		findResult: &model.ClientFundPosition{
+			ClientID:            99,
+			OwnerType:           model.OwnerTypeClient,
+			FundID:              1,
+			TotalInvestedAmount: 1000,
+		},
+		findByFundRes: []model.ClientFundPosition{
+			{ClientID: 99, OwnerType: model.OwnerTypeClient, FundID: 1, TotalInvestedAmount: 1000},
+			{ClientID: 100, OwnerType: model.OwnerTypeClient, FundID: 1, TotalInvestedAmount: 1000},
+		},
+	}
+	bankingClient := &fakeFundBankingClient{
+		accountsByNumber: map[string]*pb.GetAccountByNumberResponse{
+			"fund-account":   {AccountNumber: "fund-account", AccountType: "Fund", CurrencyCode: "RSD", AvailableBalance: 4000},
+			"client-account": {AccountNumber: "client-account", ClientId: 99, AccountType: "Current", CurrencyCode: "RSD"},
+		},
+	}
+
+	exchange := defaultExchange()
+	svc := NewInvestmentFundService(&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeListingRepo{}, &fakeInvestmentRepo{}, &fakeRedemptionRepo{}, &fakeAssetOwnershipRepo{}, &fakeExchangeRepo{exchange: exchange}, &fakeStockRepo{}, &fakeOptionRepo{}, &fakeFuturesRepo{}, &fakeForexRepo{}, bankingClient, &fakeFundUserClient{}, nil)
+
+	resp, err := svc.WithdrawFromFund(fundClientCtx(), 1, dto.WithdrawFromFundRequest{
+		AccountNumber: "client-account",
+		Amount:        1500,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, model.FundRedemptionCompleted, resp.Status)
+	require.Equal(t, 1500.0, resp.WithdrawnAmountRSD)
+	require.InDelta(t, 250.0, resp.TotalInvestedRSD, 0.0001)
+	require.NotNil(t, positionRepo.upserted)
+	require.InDelta(t, 250.0, positionRepo.upserted.UnitsOwned, 0.0001)
+	require.InDelta(t, 250.0, positionRepo.upserted.TotalInvestedAmount, 0.0001)
+	require.Len(t, bankingClient.payments, 1)
+}
+
 func validFundRequest() dto.CreateFundRequest {
 	return dto.CreateFundRequest{
 		Name:                "Alpha Growth Fund",
@@ -1166,6 +1205,59 @@ func TestProcessPendingRedemption_Success(t *testing.T) {
 	require.Equal(t, "client-acc", bankingClient.payments[0].RecipientAccountNumber)
 	require.NotNil(t, positionRepo.upserted)
 	require.Equal(t, 1500.0, positionRepo.upserted.TotalInvestedAmount)
+}
+
+func TestProcessPendingRedemption_LegacyPositionUsesNAV(t *testing.T) {
+	fund := &model.InvestmentFund{
+		FundID:        1,
+		Name:          "Test Fund",
+		AccountNumber: "fund-acc",
+	}
+	redemption := &model.ClientFundRedemption{
+		ClientFundRedemptionID: 10,
+		ClientID:               99,
+		OwnerType:              model.OwnerTypeClient,
+		FundID:                 1,
+		Fund:                   *fund,
+		AccountNumber:          "client-acc",
+		Amount:                 1500,
+		Status:                 model.FundRedemptionPendingLiquidation,
+	}
+	positionRepo := &fakePositionRepo{
+		findResult: &model.ClientFundPosition{
+			ClientID:            99,
+			OwnerType:           model.OwnerTypeClient,
+			FundID:              1,
+			TotalInvestedAmount: 1000,
+		},
+		findByFundRes: []model.ClientFundPosition{
+			{ClientID: 99, OwnerType: model.OwnerTypeClient, FundID: 1, TotalInvestedAmount: 1000},
+			{ClientID: 100, OwnerType: model.OwnerTypeClient, FundID: 1, TotalInvestedAmount: 1000},
+		},
+	}
+	redemptionRepo := &fakeRedemptionRepo{}
+	bankingClient := &fakeFundBankingClient{
+		accountsByNumber: map[string]*pb.GetAccountByNumberResponse{
+			"fund-acc":   {AccountNumber: "fund-acc", AvailableBalance: 5000, CurrencyCode: "RSD"},
+			"client-acc": {AccountNumber: "client-acc", ClientId: 99, CurrencyCode: "RSD"},
+		},
+	}
+
+	exchange := defaultExchange()
+	svc := NewInvestmentFundService(
+		&fakeFundRepo{findByIDResult: fund}, positionRepo, &fakeListingRepo{},
+		&fakeInvestmentRepo{}, redemptionRepo, &fakeAssetOwnershipRepo{},
+		&fakeExchangeRepo{exchange: exchange}, &fakeStockRepo{},
+		&fakeOptionRepo{}, &fakeFuturesRepo{}, &fakeForexRepo{},
+		bankingClient, &fakeFundUserClient{}, nil,
+	)
+
+	err := svc.processPendingRedemption(context.Background(), redemption)
+	require.NoError(t, err)
+	require.Len(t, bankingClient.payments, 1)
+	require.NotNil(t, positionRepo.upserted)
+	require.InDelta(t, 400.0, positionRepo.upserted.UnitsOwned, 0.0001)
+	require.InDelta(t, 400.0, positionRepo.upserted.TotalInvestedAmount, 0.0001)
 }
 
 func TestProcessPendingRedemption_BankingClientFails(t *testing.T) {

--- a/services/trading-service/internal/service/investment_fund_test.go
+++ b/services/trading-service/internal/service/investment_fund_test.go
@@ -2010,6 +2010,65 @@ func TestGetClientFundPositions_UsesUnitsForShareAndProfit(t *testing.T) {
 	require.InDelta(t, 600.0, resp[0].TotalProfit, 0.0001)
 }
 
+func TestGetClientFundPositions_MixedLegacyAndUnitsShareProfit(t *testing.T) {
+	fund := model.InvestmentFund{
+		FundID:        1,
+		Name:          "Mixed Fund",
+		Description:   "legacy + units",
+		AccountNumber: "fund-account",
+	}
+
+	positionRepo := &fakePositionRepo{
+		findByClientRes: []model.ClientFundPosition{
+			{
+				ClientID:            1,
+				OwnerType:           model.OwnerTypeClient,
+				FundID:              fund.FundID,
+				Fund:                &fund,
+				TotalInvestedAmount: 1000,
+			},
+		},
+		findByFundRes: []model.ClientFundPosition{
+			{ClientID: 1, OwnerType: model.OwnerTypeClient, FundID: fund.FundID, TotalInvestedAmount: 1000},
+			{ClientID: 2, OwnerType: model.OwnerTypeClient, FundID: fund.FundID, UnitsOwned: 500, TotalInvestedAmount: 500},
+		},
+	}
+
+	bankingClient := &fakeFundBankingClient{
+		accountsByNumber: map[string]*pb.GetAccountByNumberResponse{
+			"fund-account": {AccountNumber: "fund-account", AvailableBalance: 3000, CurrencyCode: "RSD"},
+		},
+	}
+
+	exchange := defaultExchange()
+	svc := NewInvestmentFundService(
+		&fakeFundRepo{findByIDResult: &fund},
+		positionRepo,
+		&fakeListingRepo{},
+		&fakeInvestmentRepo{},
+		&fakeRedemptionRepo{},
+		&fakeAssetOwnershipRepo{},
+		&fakeExchangeRepo{exchange: exchange},
+		&fakeStockRepo{},
+		&fakeOptionRepo{},
+		&fakeFuturesRepo{},
+		&fakeForexRepo{},
+		bankingClient,
+		&fakeFundUserClient{},
+		nil,
+	)
+
+	resp, err := svc.GetClientFundPositions(context.Background(), 1)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	// total units = 1000 (legacy fallback) + 500 = 1500
+	// client 1 share = 1000/1500 = 66.6667%
+	// fund value = 3000, share value = 2000, profit = 2000 - 1000 = 1000
+	require.InDelta(t, 66.6667, resp[0].ClientsSharePercent, 0.0001)
+	require.InDelta(t, 2000.0, resp[0].ClientsShareValueRSD, 0.0001)
+	require.InDelta(t, 1000.0, resp[0].TotalProfit, 0.0001)
+}
+
 func TestInvestInFund_UsesNAVToCalculateUnits(t *testing.T) {
 	fund := &model.InvestmentFund{
 		FundID:              1,
@@ -2059,4 +2118,26 @@ func TestInvestInFund_UsesNAVToCalculateUnits(t *testing.T) {
 	require.InDelta(t, 500.0, positionRepo.upserted.UnitsOwned, 0.0001)
 	require.InDelta(t, 1000.0, positionRepo.upserted.TotalInvestedAmount, 0.0001)
 	require.Equal(t, 1000.0, resp.TotalInvestedRSD)
+}
+
+func TestApplyRedemptionToPosition_MultiplePartialRedemptionsPreserveProportionalCostBasis(t *testing.T) {
+	position := &model.ClientFundPosition{
+		ClientID:            99,
+		OwnerType:           model.OwnerTypeClient,
+		FundID:              1,
+		UnitsOwned:          1000,
+		TotalInvestedAmount: 1000,
+	}
+
+	nav := 2.0
+	applyRedemptionToPosition(position, 500, nav)
+	require.InDelta(t, 750.0, position.UnitsOwned, 0.0001)
+	require.InDelta(t, 750.0, position.TotalInvestedAmount, 0.0001)
+
+	applyRedemptionToPosition(position, 500, nav)
+	require.InDelta(t, 500.0, position.UnitsOwned, 0.0001)
+	require.InDelta(t, 500.0, position.TotalInvestedAmount, 0.0001)
+
+	avgCostPerUnit := position.TotalInvestedAmount / position.UnitsOwned
+	require.InDelta(t, 1.0, avgCostPerUnit, 0.0001)
 }

--- a/services/trading-service/internal/service/investment_fund_test.go
+++ b/services/trading-service/internal/service/investment_fund_test.go
@@ -1859,3 +1859,112 @@ func TestValidateFundAccount_EmployeeBankAccountSuccess(t *testing.T) {
 	require.NotNil(t, account)
 	require.Equal(t, "BANK-ACC", account.GetAccountNumber())
 }
+
+func TestGetClientFundPositions_UsesUnitsForShareAndProfit(t *testing.T) {
+	fund := model.InvestmentFund{
+		FundID:        1,
+		Name:          "Growth Fund",
+		Description:   "Growth strategy",
+		AccountNumber: "fund-account",
+	}
+
+	positionRepo := &fakePositionRepo{
+		findByClientRes: []model.ClientFundPosition{
+			{
+				ClientID:            1,
+				OwnerType:           model.OwnerTypeClient,
+				FundID:              fund.FundID,
+				Fund:                &fund,
+				UnitsOwned:          1000,
+				TotalInvestedAmount: 1000,
+			},
+		},
+		findByFundRes: []model.ClientFundPosition{
+			{ClientID: 1, OwnerType: model.OwnerTypeClient, FundID: fund.FundID, UnitsOwned: 1000, TotalInvestedAmount: 1000},
+			{ClientID: 2, OwnerType: model.OwnerTypeClient, FundID: fund.FundID, UnitsOwned: 1000, TotalInvestedAmount: 1000},
+			{ClientID: 3, OwnerType: model.OwnerTypeClient, FundID: fund.FundID, UnitsOwned: 500, TotalInvestedAmount: 1000},
+		},
+	}
+
+	bankingClient := &fakeFundBankingClient{
+		accountsByNumber: map[string]*pb.GetAccountByNumberResponse{
+			"fund-account": {AccountNumber: "fund-account", AvailableBalance: 4000, CurrencyCode: "RSD"},
+		},
+	}
+
+	exchange := defaultExchange()
+	svc := NewInvestmentFundService(
+		&fakeFundRepo{findByIDResult: &fund},
+		positionRepo,
+		&fakeListingRepo{},
+		&fakeInvestmentRepo{},
+		&fakeRedemptionRepo{},
+		&fakeAssetOwnershipRepo{},
+		&fakeExchangeRepo{exchange: exchange},
+		&fakeStockRepo{},
+		&fakeOptionRepo{},
+		&fakeFuturesRepo{},
+		&fakeForexRepo{},
+		bankingClient,
+		&fakeFundUserClient{},
+		nil,
+	)
+
+	resp, err := svc.GetClientFundPositions(context.Background(), 1)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	require.InDelta(t, 40.0, resp[0].ClientsSharePercent, 0.0001)
+	require.InDelta(t, 1600.0, resp[0].ClientsShareValueRSD, 0.0001)
+	require.InDelta(t, 600.0, resp[0].TotalProfit, 0.0001)
+}
+
+func TestInvestInFund_UsesNAVToCalculateUnits(t *testing.T) {
+	fund := &model.InvestmentFund{
+		FundID:              1,
+		Name:                "Growth Fund",
+		MinimumContribution: 10,
+		AccountNumber:       "fund-account",
+	}
+
+	positionRepo := &fakePositionRepo{
+		findByFundRes: []model.ClientFundPosition{
+			{ClientID: 1, OwnerType: model.OwnerTypeClient, FundID: 1, UnitsOwned: 1000, TotalInvestedAmount: 1000},
+			{ClientID: 2, OwnerType: model.OwnerTypeClient, FundID: 1, UnitsOwned: 1000, TotalInvestedAmount: 1000},
+		},
+	}
+
+	bankingClient := &fakeFundBankingClient{
+		accountsByNumber: map[string]*pb.GetAccountByNumberResponse{
+			"client-account": {AccountNumber: "client-account", ClientId: 99, AccountType: "Current", CurrencyCode: "RSD"},
+			"fund-account":   {AccountNumber: "fund-account", AccountType: "Fund", CurrencyCode: "RSD", AvailableBalance: 4000},
+		},
+	}
+
+	exchange := defaultExchange()
+	svc := NewInvestmentFundService(
+		&fakeFundRepo{findByIDResult: fund},
+		positionRepo,
+		&fakeListingRepo{},
+		&fakeInvestmentRepo{},
+		&fakeRedemptionRepo{},
+		&fakeAssetOwnershipRepo{},
+		&fakeExchangeRepo{exchange: exchange},
+		&fakeStockRepo{},
+		&fakeOptionRepo{},
+		&fakeFuturesRepo{},
+		&fakeForexRepo{},
+		bankingClient,
+		&fakeFundUserClient{},
+		nil,
+	)
+
+	resp, err := svc.InvestInFund(fundClientCtx(), 1, dto.InvestInFundRequest{
+		AccountNumber: "client-account",
+		Amount:        1000,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, positionRepo.upserted)
+	require.InDelta(t, 500.0, positionRepo.upserted.UnitsOwned, 0.0001)
+	require.InDelta(t, 1000.0, positionRepo.upserted.TotalInvestedAmount, 0.0001)
+	require.Equal(t, 1000.0, resp.TotalInvestedRSD)
+}


### PR DESCRIPTION
This pull request introduces support for unit-based accounting in investment fund positions, transitioning from tracking only invested amounts to also tracking the number of fund units owned by each client. It updates the logic for investing, withdrawing, and reporting to use units and Net Asset Value (NAV), ensuring backward compatibility with legacy data. The changes also introduce helper functions for accurate calculations and add comprehensive tests for legacy scenarios.

**Core logic and data model improvements:**

* Added a new `UnitsOwned` field to the `ClientFundPosition` model, enabling explicit tracking of fund units alongside invested amounts. Upserts and seed data now populate this field. [[1]](diffhunk://#diff-944f18d036f41c2fdae074934eef6e8c716b67740cfe2fe80af729eebad21410R23) [[2]](diffhunk://#diff-c0388ebd63d6cc306036d6c0e513ad7630a66d4071ea2dd6891e8a850f213704L38-R38) [[3]](diffhunk://#diff-82b5f68e9f8f339c85735a672ee9debf81eb46b7f650338a7b7964915021e243R61)
* Introduced helper functions such as `unitsFromPosition`, `calculateFundNAV`, and `applyRedemptionToPosition` to handle calculations involving units, NAV, and legacy data. [[1]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dR77-R100) [[2]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dL772-L782)

**Business logic changes:**

* Updated investment flows to calculate units bought based on NAV, store them, and update both units and invested amounts on subsequent investments. [[1]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dR364-R372) [[2]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dR413-R418)
* Modified withdrawal and redemption logic to use units and NAV for determining available value, enforcing correct limits, and updating positions accordingly. [[1]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dL422-R464) [[2]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dL431-R478) [[3]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dL497-R552) [[4]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dL511-R566) [[5]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dL695-R756)

**Reporting and calculations:**

* Changed fund position summaries and related calculations to use units and NAV instead of only invested amounts, ensuring accurate percentage and value reporting. [[1]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dL173-R221) [[2]](diffhunk://#diff-e18b2ff5323c095dd71ee956e8bae8bd0cc6ddac105ce9b681ba33687400f38dL811-R933)

**Testing and backward compatibility:**

* Added tests to verify correct handling of legacy fund positions (without explicit units) during withdrawals and redemptions, ensuring NAV-based calculations are used for such cases. [[1]](diffhunk://#diff-740ff175c4fca032e71abb786b77e1debff556f044253f0fb6a21c473a329db2R816-R854) [[2]](diffhunk://#diff-740ff175c4fca032e71abb786b77e1debff556f044253f0fb6a21c473a329db2R1210-R1262)