### PR TITLE
Update investment fund tests and add Dockerfile for protobuf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+PROTOC_VERSION ?= 34.0
+PROTOC_GEN_GO_VERSION ?= v1.36.11
+PROTOC_GEN_GO_GRPC_VERSION ?= v1.6.1
+PROTO_IMAGE ?= banka-4-backend-proto:protoc-$(PROTOC_VERSION)-go-$(PROTOC_GEN_GO_VERSION)-grpc-$(PROTOC_GEN_GO_GRPC_VERSION)
+PROTO_FILES := $(wildcard common/proto/*.proto)
+PROTO_GENERATED_FILES := common/pkg/pb
+
+.PHONY: docker-up-build docker-up docker-down docker-down-rm-vol format swagger-docs proto proto-docker proto-image internal-proto proto-check test test-integration coverage-profile coverage coverage-report coverage-html
+
 docker-up-build:
 	docker compose -f docker-compose-dev.yml up --build
 
@@ -19,8 +28,30 @@ swagger-docs:
 	cd services/trading-service && swag init -g cmd/main.go -d ./,../../common
 	cd services/email-service && swag init -g cmd/main.go -d ./,../../common
 
-proto:
+proto: proto-docker
+
+proto-docker: proto-image
+	docker run --rm \
+		--user "$$(id -u):$$(id -g)" \
+		-v "$(CURDIR):/workspace" \
+		-w /workspace \
+		$(PROTO_IMAGE) \
+		make internal-proto
+
+proto-image:
+	docker build \
+		-f docker/Dockerfile-proto \
+		--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
+		--build-arg PROTOC_GEN_GO_VERSION=$(PROTOC_GEN_GO_VERSION) \
+		--build-arg PROTOC_GEN_GO_GRPC_VERSION=$(PROTOC_GEN_GO_GRPC_VERSION) \
+		-t $(PROTO_IMAGE) \
+		.
+
+internal-proto:
 	protoc --proto_path=. --go_out=. --go-grpc_out=. common/proto/*.proto
+
+proto-check: proto-docker
+	git diff --exit-code -- $(PROTO_FILES) $(PROTO_GENERATED_FILES)
 
 test:
 	go test ./common/... ./services/user-service/... ./services/banking-service/... ./services/trading-service/... ./services/email-service/...

--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@ make swagger-docs
 
 ## Protobuf
 
-Generate Go and gRPC code from protobuf definitions.
+Generate Go and gRPC code from protobuf definitions. This uses a pinned Docker image so all developers and CI use the same `protoc`, `protoc-gen-go`, and `protoc-gen-go-grpc` versions.
 
 ```bash
 make proto
+```
+
+Check that generated protobuf files are up to date:
+
+```bash
+make proto-check
 ```
 
 ## Testing

--- a/docker/Dockerfile-proto
+++ b/docker/Dockerfile-proto
@@ -1,0 +1,32 @@
+FROM golang:1.26-bookworm
+
+ARG PROTOC_VERSION=34.0
+ARG PROTOC_GEN_GO_VERSION=v1.36.11
+ARG PROTOC_GEN_GO_GRPC_VERSION=v1.6.1
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    arch="${TARGETARCH:-$(uname -m)}"; \
+    case "$arch" in \
+        amd64|x86_64) protoc_arch="x86_64" ;; \
+        arm64|aarch64) protoc_arch="aarch_64" ;; \
+        *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/protoc.zip \
+        "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip"; \
+    unzip -q /tmp/protoc.zip -d /usr/local; \
+    rm /tmp/protoc.zip
+
+ENV GOBIN=/usr/local/bin
+
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} \
+    && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION} \
+    && protoc --version \
+    && protoc-gen-go --version \
+    && protoc-gen-go-grpc --version
+
+WORKDIR /workspace

--- a/services/trading-service/internal/integration_test/investment_fund_integration_test.go
+++ b/services/trading-service/internal/integration_test/investment_fund_integration_test.go
@@ -524,7 +524,7 @@ func TestGetFundDetail_InvalidID(t *testing.T) {
 
 	auth := authHeaderForClient(t, 10, 100)
 	rec := performRequest(t, router, http.MethodGet, "/api/investment-funds/abc", nil, auth)
-	require.NotEqual(t, http.StatusOK, rec.Code)
+	requireStatus(t, rec, http.StatusBadRequest)
 }
 
 func TestInvestInFund_InvalidFundID(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a standardized, Docker-based workflow for generating and checking protobuf files to ensure consistent builds across all development and CI environments. The changes include a new Dockerfile for building the protobuf toolchain, Makefile targets to use Docker for code generation, and documentation updates to guide developers on the new process. Additionally, a minor test improvement was made for clarity in status code assertions.

**Protobuf code generation and consistency improvements:**

* Added `docker/Dockerfile-proto` to build a Docker image with pinned versions of `protoc`, `protoc-gen-go`, and `protoc-gen-go-grpc`, ensuring consistent protobuf code generation across environments.
* Updated the `Makefile` to introduce new targets: `proto-image` (builds the Docker image), `proto-docker` (runs code generation inside Docker), `proto` (now depends on Docker-based generation), and `proto-check` (verifies generated files are up to date). [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R9) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L22-R55)
* Documented the new protobuf workflow in `README.md`, explaining the Docker-based approach and how to check for up-to-date generated files.

**Testing improvements:**

* Improved the integration test `TestGetFundDetail_InvalidID` to assert specifically for a `400 Bad Request` status instead of simply not being `200 OK`, making the test more precise.