### PR TITLE
feat: add email notifications for payment, transfer and limit change

### DIFF
--- a/services/banking-service/internal/integration_test/setup_test.go
+++ b/services/banking-service/internal/integration_test/setup_test.go
@@ -213,8 +213,8 @@ func setupTestRouter(t *testing.T, db *gorm.DB) *gin.Engine {
 	payeeSvc := service.NewPayeeService(payeeRepo)
 	exchangeSvc := service.NewExchangeService(exchangeRateRepo, nil)
 	transactionProcessor := service.NewTransactionProcessor(accountRepo, transactionRepo, txManager)
-	paymentSvc := service.NewPaymentService(paymentRepo, transactionRepo, accountRepo, mobileSecretCl, converter, txManager, transactionProcessor)
-	transferSvc := service.NewTransferService(transferRepo, transactionRepo, accountRepo, converter, txManager, transactionProcessor)
+	paymentSvc := service.NewPaymentService(paymentRepo, transactionRepo, accountRepo, mobileSecretCl, converter, txManager, transactionProcessor, userCl, mailer)
+	transferSvc := service.NewTransferService(transferRepo, transactionRepo, accountRepo, converter, txManager, transactionProcessor, userCl, mailer)
 	loanSvc := service.NewLoanService(accountRepo, loanTypeRepo, loanRequestRepo, loanRepo, transactionProcessor, txManager, userCl, mailer)
 
 	healthHandler := handler.NewHealthHandler()

--- a/services/banking-service/internal/service/account_service.go
+++ b/services/banking-service/internal/service/account_service.go
@@ -294,7 +294,7 @@ func (s *AccountService) ConfirmLimitsChange(ctx context.Context, accountNumber 
 		return errors.BadRequestErr("invalid verification code")
 	}
 
-	return s.txManager.WithinTransaction(ctx, func(txCtx context.Context) error {
+	if err := s.txManager.WithinTransaction(ctx, func(txCtx context.Context) error {
 		if err := s.repo.UpdateLimits(txCtx, accountNumber, token.NewDailyLimit, token.NewMonthlyLimit); err != nil {
 			return errors.InternalErr(err)
 		}
@@ -302,7 +302,35 @@ func (s *AccountService) ConfirmLimitsChange(ctx context.Context, accountNumber 
 			return errors.InternalErr(err)
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	return s.sendLimitsChangedEmail(ctx, accountNumber, clientID, token.NewDailyLimit, token.NewMonthlyLimit)
+}
+
+func (s *AccountService) sendLimitsChangedEmail(ctx context.Context, accountNumber string, clientID uint, daily, monthly float64) error {
+	clientInfo, err := s.userClient.GetClientByID(ctx, clientID)
+	if err != nil {
+		return err
+	}
+	if clientInfo == nil {
+		return errors.InternalErr(fmt.Errorf("client not found in user service"))
+	}
+
+	body := fmt.Sprintf(
+		"Hello %s,\n\nThe limits for your account %s have been updated.\n\nNew daily limit: %.2f\nNew monthly limit: %.2f",
+		defaultContactName(clientInfo.FullName),
+		accountNumber,
+		daily,
+		monthly,
+	)
+
+	if err := s.mailer.Send(clientInfo.Email, "Account limits changed", body); err != nil {
+		return errors.ServiceUnavailableErr(err)
+	}
+
+	return nil
 }
 
 // ...existing code...

--- a/services/banking-service/internal/service/payment_service.go
+++ b/services/banking-service/internal/service/payment_service.go
@@ -28,6 +28,8 @@ type PaymentService struct {
 	exchangeService      CurrencyConverter
 	txManager            repository.TransactionManager
 	transactionProcessor paymentTransactionProcessor
+	userClient           client.UserClient
+	mailer               Mailer
 	now                  func() time.Time
 }
 
@@ -39,6 +41,8 @@ func NewPaymentService(
 	exchangeService CurrencyConverter,
 	txManager repository.TransactionManager,
 	transactionProcessor *TransactionProcessor,
+	userClient client.UserClient,
+	mailer Mailer,
 ) *PaymentService {
 	return &PaymentService{
 		paymentRepo:          paymentRepo,
@@ -48,6 +52,8 @@ func NewPaymentService(
 		exchangeService:      exchangeService,
 		txManager:            txManager,
 		transactionProcessor: transactionProcessor,
+		userClient:           userClient,
+		mailer:               mailer,
 		now:                  time.Now,
 	}
 }
@@ -303,5 +309,36 @@ func (s *PaymentService) VerifyPayment(ctx context.Context, id uint, code, autho
 		return nil, err
 	}
 
+	if err := s.sendPaymentExecutedEmail(ctx, payerAccount.ClientID, payment); err != nil {
+		return nil, err
+	}
+
 	return payment, nil
+}
+
+func (s *PaymentService) sendPaymentExecutedEmail(ctx context.Context, clientID uint, payment *model.Payment) error {
+	clientInfo, err := s.userClient.GetClientByID(ctx, clientID)
+	if err != nil {
+		return err
+	}
+	if clientInfo == nil {
+		return errors.InternalErr(fmt.Errorf("client not found in user service"))
+	}
+
+	body := fmt.Sprintf(
+		"Hello %s,\n\nYour payment has been successfully executed.\n\nFrom: %s\nTo: %s (%s)\nAmount: %.2f %s\nPurpose: %s",
+		defaultContactName(clientInfo.FullName),
+		payment.Transaction.PayerAccountNumber,
+		payment.RecipientName,
+		payment.Transaction.RecipientAccountNumber,
+		payment.Transaction.StartAmount,
+		payment.Transaction.StartCurrencyCode,
+		payment.Purpose,
+	)
+
+	if err := s.mailer.Send(clientInfo.Email, "Payment executed", body); err != nil {
+		return errors.ServiceUnavailableErr(err)
+	}
+
+	return nil
 }

--- a/services/banking-service/internal/service/payment_service_full_test.go
+++ b/services/banking-service/internal/service/payment_service_full_test.go
@@ -323,6 +323,8 @@ func TestVerifyPayment_MobileSecretError(t *testing.T) {
 		mobileSecretClient:   &fakeMobileSecretClient{err: errors.New("secret service down")},
 		txManager:            &fakeBankingTxManager{},
 		transactionProcessor: &fakeVerifyTransactionProcessor{},
+		userClient:           &fakeUserClient{},
+		mailer:               &fakeAccountServiceMailer{},
 	}
 
 	_, err := svc.VerifyPayment(ctx, 1, "123456", "Bearer token")
@@ -354,6 +356,8 @@ func TestVerifyPayment_MagicCode123456Success(t *testing.T) {
 		mobileSecretClient:   &fakeMobileSecretClient{secret: "JBSWY3DPEHPK3PXP"},
 		transactionProcessor: processor,
 		txManager:            &fakeBankingTxManager{},
+		userClient:           &fakeUserClient{},
+		mailer:               &fakeAccountServiceMailer{},
 	}
 
 	payment, err := svc.VerifyPayment(ctx, 1, "123456", "Bearer token")

--- a/services/banking-service/internal/service/payment_service_test.go
+++ b/services/banking-service/internal/service/payment_service_test.go
@@ -234,6 +234,8 @@ func newTestPaymentService(
 		mobileSecretClient:   &fakeMobileSecretClient{},
 		txManager:            &fakeBankingTxManager{},
 		transactionProcessor: &fakeVerifyTransactionProcessor{},
+		userClient:           &fakeUserClient{},
+		mailer:               &fakeAccountServiceMailer{},
 		now:                  time.Now,
 	}
 }

--- a/services/banking-service/internal/service/payment_service_test.go
+++ b/services/banking-service/internal/service/payment_service_test.go
@@ -521,6 +521,8 @@ func TestVerifyPayment_InvalidCode(t *testing.T) {
 		mobileSecretClient:   &fakeMobileSecretClient{secret: "JBSWY3DPEHPK3PXP"},
 		transactionProcessor: processor,
 		now:                  func() time.Time { return time.Unix(59, 0) },
+		userClient:           &fakeUserClient{},
+		mailer:               &fakeAccountServiceMailer{},
 	}
 
 	payment, err := svc.VerifyPayment(authCtx, 1, "000000", "Bearer token")
@@ -553,6 +555,8 @@ func TestVerifyPayment_CancelAfter3FailedAttempts(t *testing.T) {
 		mobileSecretClient:   &fakeMobileSecretClient{secret: "JBSWY3DPEHPK3PXP"},
 		transactionProcessor: processor,
 		now:                  func() time.Time { return time.Unix(59, 0) },
+		userClient:           &fakeUserClient{},
+		mailer:               &fakeAccountServiceMailer{},
 	}
 
 	payment, err := svc.VerifyPayment(authCtx, 1, "000000", "Bearer token")
@@ -586,6 +590,8 @@ func TestVerifyPayment_FailedAttemptsBelow3DoNotCancel(t *testing.T) {
 		mobileSecretClient:   &fakeMobileSecretClient{secret: "JBSWY3DPEHPK3PXP"},
 		transactionProcessor: processor,
 		now:                  func() time.Time { return time.Unix(59, 0) },
+		userClient:           &fakeUserClient{},
+		mailer:               &fakeAccountServiceMailer{},
 	}
 
 	payment, err := svc.VerifyPayment(authCtx, 1, "000000", "Bearer token")
@@ -617,6 +623,8 @@ func TestVerifyPayment_Success(t *testing.T) {
 		mobileSecretClient:   &fakeMobileSecretClient{secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"},
 		transactionProcessor: processor,
 		now:                  func() time.Time { return time.Unix(59, 0) },
+		userClient:           &fakeUserClient{},
+		mailer:               &fakeAccountServiceMailer{},
 	}
 
 	payment, err := svc.VerifyPayment(authCtx, 1, "287082", "Bearer token")

--- a/services/banking-service/internal/service/transfer_service.go
+++ b/services/banking-service/internal/service/transfer_service.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/RAF-SI-2025/Banka-4-Backend/common/pkg/auth"
 	"github.com/RAF-SI-2025/Banka-4-Backend/common/pkg/errors"
+	"github.com/RAF-SI-2025/Banka-4-Backend/services/banking-service/internal/client"
 	"github.com/RAF-SI-2025/Banka-4-Backend/services/banking-service/internal/dto"
 	"github.com/RAF-SI-2025/Banka-4-Backend/services/banking-service/internal/model"
 	"github.com/RAF-SI-2025/Banka-4-Backend/services/banking-service/internal/repository"
@@ -34,6 +36,8 @@ type TransferService struct {
 	exchangeService      CurrencyConverter
 	txManager            repository.TransactionManager
 	transactionProcessor *TransactionProcessor
+	userClient           client.UserClient
+	mailer               Mailer
 }
 
 func NewTransferService(
@@ -43,6 +47,8 @@ func NewTransferService(
 	exchangeService CurrencyConverter,
 	txManager repository.TransactionManager,
 	transactionProcessor *TransactionProcessor,
+	userClient client.UserClient,
+	mailer Mailer,
 ) *TransferService {
 	return &TransferService{
 		transferRepo:         transferRepo,
@@ -51,6 +57,8 @@ func NewTransferService(
 		exchangeService:      exchangeService,
 		txManager:            txManager,
 		transactionProcessor: transactionProcessor,
+		userClient:           userClient,
+		mailer:               mailer,
 	}
 }
 
@@ -105,8 +113,37 @@ func (s *TransferService) ExecuteTransfer(ctx context.Context, req dto.TransferR
 		return nil, err
 	}
 
+	if err := s.sendTransferExecutedEmail(ctx, clientID, createdTransfer); err != nil {
+		return nil, err
+	}
+
 	response := dto.ToTransferResponse(createdTransfer)
 	return &response, nil
+}
+
+func (s *TransferService) sendTransferExecutedEmail(ctx context.Context, clientID uint, transfer *model.Transfer) error {
+	clientInfo, err := s.userClient.GetClientByID(ctx, clientID)
+	if err != nil {
+		return err
+	}
+	if clientInfo == nil {
+		return errors.InternalErr(fmt.Errorf("client not found in user service"))
+	}
+
+	body := fmt.Sprintf(
+		"Hello %s,\n\nYour transfer has been successfully executed.\n\nFrom: %s\nTo: %s\nAmount: %.2f %s",
+		defaultContactName(clientInfo.FullName),
+		transfer.Transaction.PayerAccountNumber,
+		transfer.Transaction.RecipientAccountNumber,
+		transfer.Transaction.StartAmount,
+		transfer.Transaction.StartCurrencyCode,
+	)
+
+	if err := s.mailer.Send(clientInfo.Email, "Transfer executed", body); err != nil {
+		return errors.ServiceUnavailableErr(err)
+	}
+
+	return nil
 }
 
 func (s *TransferService) GetTransferHistory(ctx context.Context, clientID uint, page, pageSize int) (*dto.ListTransfersResponse, error) {

--- a/services/banking-service/internal/service/transfer_service_test.go
+++ b/services/banking-service/internal/service/transfer_service_test.go
@@ -583,7 +583,7 @@ func newTransferServiceForTests(accounts []model.Account, converter *fakeTransfe
 	}
 
 	transactionProcessor := NewTransactionProcessor(accountRepo, transactionRepo, txManager)
-	service := NewTransferService(transferRepo, transactionRepo, accountRepo, converter, txManager, transactionProcessor)
+	service := NewTransferService(transferRepo, transactionRepo, accountRepo, converter, txManager, transactionProcessor, &fakeUserClient{}, &fakeAccountServiceMailer{})
 	return &transferTestEnv{
 		service:         service,
 		accountRepo:     accountRepo,


### PR DESCRIPTION
Implemented email notifications for the following events:                                                                                                                         
1. Payment executed
2. Transfer executed                                                                                                                                                               
3. Account limit changed

  Email notifications for card blocking, loan creation and loan approval already existed.
  Used the existing Mailer interface and UserClient, following the same pattern as CardService and LoanService.