### PR TITLE
CD: Kubernetes automatic deployment restart after image build

### DIFF
--- a/.github/workflows/.env.example
+++ b/.github/workflows/.env.example
@@ -2,6 +2,7 @@ PORT=8080
 BANKING_SERVICE_PORT=8081
 TRADING_SERVICE_PORT=8082
 INTERBANK_SERVICE_PORT=8083
+EMAIL_SERVICE_PORT=8084
 
 DB_HOST=user_service_db
 DB_PORT=5432
@@ -23,3 +24,5 @@ BACKEND_BASE_URL=http://localhost:8080
 
 # EXCHANGE_RATE_API_KEY=your_exchange_rate_api_key
 # FINNHUB_API_KEY=your_finnhub_api_key
+
+INTERBANK_PEERS_CONFIG_PATH=/app/services/interbank-service/peers.example.yaml

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,5 @@
-name: Docker Build
-run-name: Docker build for ${{ github.repository }}
+name: Docker Build and Kubernetes Deploy
+run-name: Docker build and K8s deploy for ${{ github.repository }}
 
 on:
   workflow_dispatch:
@@ -53,4 +53,29 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
+  deploy-k8s:
+    name: Kubernetes deploy ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    needs: docker-build
+    if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - banking-service
+          - email-service
+          - interbank-service
+          - trading-service
+          - user-service
+    
+    steps:
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
+        with:
+          version: 'v1.35.5'
 
+      - name: Configure kubectl
+        run: echo "${{ secrets.KUBE_CONFIG }}" | base64 --decode > .kube/config
+
+      - name: Deploy to Kubernetes
+        run: kubectl rollout restart deployment ${{ matrix.service }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -75,7 +75,10 @@ jobs:
           version: 'v1.35.5'
 
       - name: Configure kubectl
-        run: echo "${{ secrets.KUBE_CONFIG }}" | base64 --decode > .kube/config
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
 
       - name: Deploy to Kubernetes
         run: kubectl rollout restart deployment ${{ matrix.service }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,55 @@ services:
     healthcheck:
       test: curl -f http://localhost:${TRADING_SERVICE_PORT}/api/health || exit 1
 
+  interbank_service:
+    image: ghcr.io/raf-si-2025/banka-4-backend/interbank-service
+    ports:
+      - "${INTERBANK_SERVICE_PORT}:${INTERBANK_SERVICE_PORT}"
+    env_file: .env
+    environment:
+      AIR_CONFIG_PATH: /app/services/interbank-service/.air.toml
+      PORT: ${INTERBANK_SERVICE_PORT}
+      INTERBANK_ROUTING_NUMBER: "444"
+      INTERBANK_PEERS_CONFIG_PATH: ${INTERBANK_PEERS_CONFIG_PATH}
+    depends_on:
+      user_service_db:
+        condition: service_healthy
+      banking_service:
+        condition: service_healthy
+      trading_service:
+        condition: service_healthy
+    healthcheck:
+      test: curl -f http://localhost:${INTERBANK_SERVICE_PORT}/api/health || exit 1
+    volumes:
+      - .:/app:z
+      - /app/tmp
+      - /go/pkg/mod
+    working_dir: /app/services/interbank-service
+
+  email_service:
+    image: ghcr.io/raf-si-2025/banka-4-backend/email-service
+    ports:
+      - "${EMAIL_SERVICE_PORT}:${EMAIL_SERVICE_PORT}"
+    env_file: .env
+    environment:
+      AIR_CONFIG_PATH: /app/services/email-service/.air.toml
+      PORT: ${EMAIL_SERVICE_PORT}
+      GRPC_PORT: "50054"
+    depends_on:
+      maildev:
+        condition: service_started
+    healthcheck:
+      test: curl -f http://localhost:${EMAIL_SERVICE_PORT}/api/health || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    volumes:
+      - .:/app:z
+      - /app/tmp
+      - /go/pkg/mod
+    working_dir: /app/services/email-service
+
   maildev:
     image: maildev/maildev:latest
     restart: unless-stopped


### PR DESCRIPTION
This PR includes a change to a workflow file for restarting Kubernetes backend services after a new image is pushed to ghcr.io.

For it to work, we need a `KUBE_CONFIG` secret repo variable that has the `kubectl` configuration file encoded in Base64.